### PR TITLE
전체 Flow 연결

### DIFF
--- a/poporazzi/App/SceneDelegate.swift
+++ b/poporazzi/App/SceneDelegate.swift
@@ -6,16 +6,34 @@
 //
 
 import UIKit
+import RxSwift
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    
+    private let disposeBag = DisposeBag()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UserDefaultsService.isTracking
-        ? MomentRecordViewController() : MomentTitleInputViewController()
+        window?.rootViewController = MomentTitleInputViewController()
         window?.makeKeyAndVisible()
+        
+        if UserDefaultsService.isTracking {
+            presentMomentRecortViewController()
+        }
+    }
+}
+
+// MARK: - Helper
+
+extension SceneDelegate {
+    
+    private func presentMomentRecortViewController() {
+        let momentRecordVC = MomentRecordViewController()
+        momentRecordVC.modalPresentationStyle = .fullScreen
+        momentRecordVC.modalTransitionStyle = .crossDissolve
+        window?.rootViewController?.present(momentRecordVC, animated: true)
     }
 }

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -50,27 +50,31 @@ extension PhotoKitService {
     
     /// 기록을 반환합니다.
     func fetchPhotos(_ fetchResult: PHFetchResult<PHAsset>?) -> Observable<[Photo]> {
-        var newImages = [UIImage]()
-        let imageManager = PHImageManager.default()
-        let requestOptions = PHImageRequestOptions()
-        requestOptions.isSynchronous = true
-        requestOptions.deliveryMode = .highQualityFormat
-        
-        fetchResult?.enumerateObjects { asset, _, _ in
-            imageManager.requestImage(
-                for: asset,
-                targetSize: .zero,
-                contentMode: .aspectFit,
-                options: requestOptions,
-                resultHandler: { image, _ in
-                    if let image = image {
-                        newImages.append(image)
+        return Observable.create { observer in
+            var newImages = [UIImage]()
+            let imageManager = PHImageManager.default()
+            let requestOptions = PHImageRequestOptions()
+            requestOptions.isSynchronous = true
+            requestOptions.deliveryMode = .highQualityFormat
+            
+            fetchResult?.enumerateObjects { asset, _, _ in
+                imageManager.requestImage(
+                    for: asset,
+                    targetSize: .init(width: 360, height: 360),
+                    contentMode: .aspectFill,
+                    options: requestOptions,
+                    resultHandler: { image, _ in
+                        if let image = image {
+                            newImages.append(image)
+                        }
                     }
-                }
-            )
+                )
+            }
+            
+            observer.onNext(newImages.map { Photo(content: $0) })
+            observer.onCompleted()
+            return Disposables.create()
         }
-        
-        return .just(newImages.map { Photo(content: $0) })
     }
     
     /// 앨범에 기록을 저장합니다.

--- a/poporazzi/Data/Service/UserDefaultsService.swift
+++ b/poporazzi/Data/Service/UserDefaultsService.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
+import RxSwift
 
-/// UserDefaults 싱글톤
+/// UserDefaults 관리 객체
 struct UserDefaultsService {
     
     @UserDefault(key: "isTracking", defaultValue: false)

--- a/poporazzi/Domain/Entity/Photo.swift
+++ b/poporazzi/Domain/Entity/Photo.swift
@@ -8,5 +8,5 @@
 import UIKit
 
 struct Photo {
-    let content: UIImage
+    var content: UIImage
 }

--- a/poporazzi/Domain/Entity/Record.swift
+++ b/poporazzi/Domain/Entity/Record.swift
@@ -1,0 +1,17 @@
+//
+//  Record.swift
+//  poporazzi
+//
+//  Created by 김민준 on 4/9/25.
+//
+
+import Foundation
+
+struct Record {
+    var title: String
+    var trackingStartDate: Date
+    
+    static var initialValue: Self {
+        Record(title: "", trackingStartDate: .now)
+    }
+}

--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
@@ -52,6 +52,7 @@ extension MomentTitleInputViewController {
         
         output.navigateToRecordView
             .bind(with: self, onNext: { owner, title in
+                owner.screen.titleTextField.textField.text?.removeAll()
                 let momentRecordVC = MomentRecordViewController()
                 momentRecordVC.modalPresentationStyle = .fullScreen
                 momentRecordVC.modalTransitionStyle = .crossDissolve

--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
@@ -23,6 +23,11 @@ final class MomentTitleInputViewController: ViewController {
         super.viewDidLoad()
         bind()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        screen.titleTextField.action(.presentKeyboard)
+    }
 }
 
 // MARK: - Binding

--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
@@ -47,7 +47,6 @@ extension MomentTitleInputViewModel {
                 UserDefaultsService.isTracking = true
                 UserDefaultsService.albumTitle = $0
                 UserDefaultsService.trackingStartDate = .now
-                output.titleTextFieldText.accept("")
             }
             .bind(to: output.navigateToRecordView)
             .disposed(by: disposeBag)

--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
@@ -47,6 +47,7 @@ extension MomentTitleInputViewModel {
                 UserDefaultsService.isTracking = true
                 UserDefaultsService.albumTitle = $0
                 UserDefaultsService.trackingStartDate = .now
+                output.titleTextFieldText.accept("")
             }
             .bind(to: output.navigateToRecordView)
             .disposed(by: disposeBag)

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
@@ -105,10 +105,7 @@ final class MomentRecordView: CodeBaseUI {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        containerView.pin
-            .top(pin.safeArea)
-            .left().right().bottom()
-        
+        containerView.pin.top(pin.safeArea).left().right().bottom()
         containerView.flex.layout()
     }
 }
@@ -124,15 +121,19 @@ extension MomentRecordView {
     }
     
     func action(_ action: Action) {
+        defer { containerView.flex.layout() }
         switch action {
         case let .setAlbumTitleLabel(title):
             albumTitleLabel.text = title
+            albumTitleLabel.flex.markDirty()
             
         case let .setTrackingStartDateLabel(text):
             trackingStartDateLabel.text = text
+            trackingStartDateLabel.flex.markDirty()
             
         case let .setTotalImageCountLabel(count):
             totalPhotoCountLabel.text = "총 \(count)장"
+            totalPhotoCountLabel.flex.markDirty()
         }
     }
 }

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
@@ -50,7 +50,7 @@ final class MomentRecordView: CodeBaseUI {
         let label = UILabel()
         label.text = "📸\n지금부터 촬영한 모든 사진과\n영상이 기록될 거에요!"
         label.numberOfLines = 3
-        label.textAlignment = .center
+        label.setLine(alignment: .center, spacing: 8)
         label.font = .setPretendard(.semiBold, 14)
         label.textColor = .subLabel
         return label

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
@@ -32,7 +32,7 @@ final class MomentRecordView: CodeBaseUI {
     /// 트래킹 시작 날짜 라벨
     private let trackingStartDateLabel: UILabel = {
         let label = UILabel()
-        label.font = .setPretendard(.semiBold, 15)
+        label.font = .setPretendard(.medium, 14)
         label.textColor = .subLabel
         return label
     }()
@@ -47,10 +47,13 @@ final class MomentRecordView: CodeBaseUI {
     
     /// 앨범 컬렉션 뷰
     lazy var albumCollectionView: UICollectionView = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.endRefreshing()
         let collectionView = UICollectionView(
             frame: .zero,
             collectionViewLayout: compositionalLayout
         )
+        collectionView.refreshControl = refreshControl
         collectionView.register(
             MomentRecordCell.self,
             forCellWithReuseIdentifier: MomentRecordCell.identifier
@@ -94,9 +97,6 @@ final class MomentRecordView: CodeBaseUI {
     init() {
         super.init(frame: .zero)
         setup()
-        action(.setAlbumTitleLabel("일본 추억 여행"))
-        action(.setTrackingStartDateLabel("2025년 4월 3일 목요일 22:25 ~"))
-        action(.setTotalImageCountLabel(56))
     }
     
     required init?(coder: NSCoder) {

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordView.swift
@@ -45,6 +45,17 @@ final class MomentRecordView: CodeBaseUI {
         return label
     }()
     
+    /// 촬영된 사진이 없을 때 라벨
+    private let emptyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "📸\n지금부터 촬영한 모든 사진과\n영상이 기록될 거에요!"
+        label.numberOfLines = 3
+        label.textAlignment = .center
+        label.font = .setPretendard(.semiBold, 14)
+        label.textColor = .subLabel
+        return label
+    }()
+    
     /// 앨범 컬렉션 뷰
     lazy var albumCollectionView: UICollectionView = {
         let refreshControl = UIRefreshControl()
@@ -132,8 +143,9 @@ extension MomentRecordView {
             trackingStartDateLabel.flex.markDirty()
             
         case let .setTotalImageCountLabel(count):
-            totalPhotoCountLabel.text = "총 \(count)장"
+            totalPhotoCountLabel.text = "총 \(count)개"
             totalPhotoCountLabel.flex.markDirty()
+            emptyLabel.flex.display(count > 0 ? .none : .flex)
         }
     }
 }
@@ -158,7 +170,10 @@ extension MomentRecordView {
                         }
                     }
                 
-                flex.addItem(albumCollectionView).grow(1).marginTop(24)
+                flex.addItem().grow(1).marginTop(24).define { flex in
+                    flex.addItem(albumCollectionView).position(.absolute).all(0)
+                    flex.addItem(emptyLabel).position(.absolute).alignSelf(.center).top(35%)
+                }
             }
     }
 }

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
@@ -16,6 +16,8 @@ final class MomentRecordViewController: ViewController {
     private let disposeBag = DisposeBag()
     private lazy var input = MomentRecordViewModel.Input(
         viewDidLoad: .just(()),
+        viewBecomeActive: NotificationCenter.default
+            .rx.notification(UIApplication.didBecomeActiveNotification).asObservable(),
         refresh: screen.albumCollectionView.refreshControl?
             .rx.controlEvent(.valueChanged).asObservable() ?? .empty(),
         finishButtonTapped: screen.finishRecordButton.button

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
@@ -48,6 +48,7 @@ extension MomentRecordViewController {
             .disposed(by: disposeBag)
         
         output.photoList
+            .observe(on: MainScheduler.instance)
             .bind(to: screen.albumCollectionView.rx.items(
                 cellIdentifier: MomentRecordCell.identifier,
                 cellType: MomentRecordCell.self
@@ -58,8 +59,10 @@ extension MomentRecordViewController {
             .disposed(by: disposeBag)
         
         output.photoList
+            .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, photos in
                 owner.screen.action(.setTotalImageCountLabel(photos.count))
+                owner.screen.albumCollectionView.refreshControl?.endRefreshing()
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
@@ -48,8 +48,8 @@ extension MomentRecordViewController {
         
         output.saveToAlbum
             .bind(with: self) { owner, _ in
-                print("저장 완료")
                 UserDefaultsService.isTracking = false
+                owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
     }

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
@@ -14,6 +14,14 @@ final class MomentRecordViewController: ViewController {
     private let screen = MomentRecordView()
     private let viewModel = MomentRecordViewModel()
     private let disposeBag = DisposeBag()
+    private lazy var input = MomentRecordViewModel.Input(
+        viewDidLoad: .just(()),
+        refresh: screen.albumCollectionView.refreshControl?
+            .rx.controlEvent(.valueChanged).asObservable() ?? .empty(),
+        finishButtonTapped: screen.finishRecordButton.button
+            .rx.tap.asObservable(),
+        saveToAlbumButtonTapped: .init()
+    )
     
     override func loadView() {
         view = screen
@@ -30,19 +38,34 @@ final class MomentRecordViewController: ViewController {
 extension MomentRecordViewController {
     
     func bind() {
-        let output = viewModel.transform(
-            MomentRecordViewModel.Input(
-                viewDidLoad: .just(()),
-                finishButtonTapped: screen.finishRecordButton.button.rx.tap.asObservable()
-            )
-        )
+        let output = viewModel.transform(input)
         
-        output.photoListResponse
+        output.currentRecord
+            .bind(with: self) { owner, record in
+                owner.screen.action(.setAlbumTitleLabel(record.title))
+                owner.screen.action(.setTrackingStartDateLabel(record.trackingStartDate.startDateFormat))
+            }
+            .disposed(by: disposeBag)
+        
+        output.photoList
             .bind(to: screen.albumCollectionView.rx.items(
                 cellIdentifier: MomentRecordCell.identifier,
                 cellType: MomentRecordCell.self
-            )) { index, photo, cell in
+            )) { [weak self] index, photo, cell in
                 cell.action(.setImage(photo.content))
+                self?.screen.albumCollectionView.refreshControl?.endRefreshing()
+            }
+            .disposed(by: disposeBag)
+        
+        output.photoList
+            .bind(with: self) { owner, photos in
+                owner.screen.action(.setTotalImageCountLabel(photos.count))
+            }
+            .disposed(by: disposeBag)
+        
+        output.finishAlertPresented
+            .bind(with: self) { owner, _ in
+                owner.showFinishAlert()
             }
             .disposed(by: disposeBag)
         
@@ -52,5 +75,29 @@ extension MomentRecordViewController {
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
+    }
+}
+
+// MARK: - Alert
+
+extension MomentRecordViewController {
+    
+    private func showFinishAlert() {
+        let title = UserDefaultsService.albumTitle
+        let totalCount = viewModel.output.photoList.value.count
+        showAlert(
+            title: "기록을 종료합니다",
+            message: "총 \(totalCount)장의 '\(title)' 기록이 종료돼요",
+            confirmTitle: "종료"
+        )
+        .subscribe { actionType in
+            switch actionType {
+            case .cancel:
+                break
+            case .confirm:
+                self.input.saveToAlbumButtonTapped.accept(())
+            }
+        }
+        .disposed(by: disposeBag)
     }
 }

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewController.swift
@@ -20,7 +20,8 @@ final class MomentRecordViewController: ViewController {
             .rx.controlEvent(.valueChanged).asObservable() ?? .empty(),
         finishButtonTapped: screen.finishRecordButton.button
             .rx.tap.asObservable(),
-        saveToAlbumButtonTapped: .init()
+        saveToAlbumButtonTapped: .init(),
+        backToHomeButtonTapped: .init()
     )
     
     override func loadView() {
@@ -74,6 +75,12 @@ extension MomentRecordViewController {
         
         output.saveToAlbum
             .bind(with: self) { owner, _ in
+                owner.showConfirmAlert()
+            }
+            .disposed(by: disposeBag)
+        
+        output.backToHome
+            .bind(with: self) { owner, _ in
                 UserDefaultsService.isTracking = false
                 owner.dismiss(animated: true)
             }
@@ -99,6 +106,24 @@ extension MomentRecordViewController {
                 break
             case .confirm:
                 self.input.saveToAlbumButtonTapped.accept(())
+            }
+        }
+        .disposed(by: disposeBag)
+    }
+    
+    private func showConfirmAlert() {
+        showAlert(
+            title: "기록이 앨범에 저장되었습니다.",
+            message: "앨범 앱을 확인해주세요!",
+            confirmTitle: "홈으로 돌아가기",
+            isContainCancel: false
+        )
+        .subscribe { actionType in
+            switch actionType {
+            case .cancel:
+                break
+            case .confirm:
+                self.input.backToHomeButtonTapped.accept(())
             }
         }
         .disposed(by: disposeBag)

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
@@ -65,6 +65,7 @@ extension MomentRecordViewModel {
             .disposed(by: disposeBag)
         
         input.refresh
+            .observe(on: ConcurrentDispatchQueueScheduler(qos: .default))
             .withUnretained(self)
             .flatMap { _ in
                 let trackingStartDate = UserDefaultsService.trackingStartDate

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
@@ -28,6 +28,7 @@ extension MomentRecordViewModel {
         let refresh: Observable<Void>
         let finishButtonTapped: Observable<Void>
         let saveToAlbumButtonTapped: PublishRelay<Void>
+        let backToHomeButtonTapped: PublishRelay<Void>
     }
     
     struct Output {
@@ -35,6 +36,7 @@ extension MomentRecordViewModel {
         let photoList: BehaviorRelay<[Photo]> = .init(value: [])
         let finishAlertPresented: PublishRelay<Void> = .init()
         let saveToAlbum: PublishRelay<Void> = .init()
+        let backToHome: PublishRelay<Void> = .init()
     }
     
     func transform(_ input: Input) -> Output {
@@ -89,6 +91,10 @@ extension MomentRecordViewModel {
                 try self?.photoKitService.saveAlbum(title: title, assets: self?.fetchResult)
             })
             .bind(to: output.saveToAlbum)
+            .disposed(by: disposeBag)
+        
+        input.backToHomeButtonTapped
+            .bind(to: output.backToHome)
             .disposed(by: disposeBag)
         
         return output

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
@@ -15,6 +15,8 @@ final class MomentRecordViewModel: ViewModel {
     private let photoKitService = PhotoKitService()
     private let disposeBag = DisposeBag()
     private var fetchResult: PHFetchResult<PHAsset>?
+    
+    let output = Output()
 }
 
 // MARK: - Input & Output
@@ -23,31 +25,64 @@ extension MomentRecordViewModel {
     
     struct Input {
         let viewDidLoad: Observable<Void>
+        let refresh: Observable<Void>
         let finishButtonTapped: Observable<Void>
+        let saveToAlbumButtonTapped: PublishRelay<Void>
     }
     
     struct Output {
-        let photoListResponse: BehaviorRelay<[Photo]> = .init(value: [])
+        let currentRecord: BehaviorRelay<Record> = .init(value: .initialValue)
+        let photoList: BehaviorRelay<[Photo]> = .init(value: [])
+        let finishAlertPresented: PublishRelay<Void> = .init()
         let saveToAlbum: PublishRelay<Void> = .init()
     }
     
     func transform(_ input: Input) -> Output {
-        let output = Output()
+        input.viewDidLoad
+            .withUnretained(self)
+            .map { _ in self.currentRecord() }
+            .bind(to: output.currentRecord)
+            .disposed(by: disposeBag)
         
         input.viewDidLoad
-            .flatMap({ [weak self] _ in
+            .withUnretained(self)
+            .flatMap { _ in
                 let trackingStartDate = UserDefaultsService.trackingStartDate
-                self?.fetchResult = self?.photoKitService.fetchAssetResult(
+                self.fetchResult = self.photoKitService.fetchAssetResult(
                     mediaFetchType: .all,
                     date: trackingStartDate,
                     ascending: true
                 )
-                return self?.photoKitService.fetchPhotos(self?.fetchResult) ?? .empty()
-            })
-            .bind(to: output.photoListResponse)
+                return self.photoKitService.fetchPhotos(self.fetchResult)
+            }
+            .bind(to: output.photoList)
+            .disposed(by: disposeBag)
+        
+        input.refresh
+            .withUnretained(self)
+            .map { _ in self.currentRecord() }
+            .bind(to: output.currentRecord)
+            .disposed(by: disposeBag)
+        
+        input.refresh
+            .withUnretained(self)
+            .flatMap { _ in
+                let trackingStartDate = UserDefaultsService.trackingStartDate
+                self.fetchResult = self.photoKitService.fetchAssetResult(
+                    mediaFetchType: .all,
+                    date: trackingStartDate,
+                    ascending: true
+                )
+                return self.photoKitService.fetchPhotos(self.fetchResult)
+            }
+            .bind(to: output.photoList)
             .disposed(by: disposeBag)
         
         input.finishButtonTapped
+            .bind(to: output.finishAlertPresented)
+            .disposed(by: disposeBag)
+        
+        input.saveToAlbumButtonTapped
             .do(onNext: { [weak self] _ in
                 let title = UserDefaultsService.albumTitle
                 try self?.photoKitService.saveAlbum(title: title, assets: self?.fetchResult)
@@ -56,5 +91,17 @@ extension MomentRecordViewModel {
             .disposed(by: disposeBag)
         
         return output
+    }
+}
+
+// MARK: - Helper
+
+extension MomentRecordViewModel {
+    
+    /// UserDefault 값을 기반으로 Record를 반환합니다.
+    private func currentRecord() -> Record {
+        let albumTitle = UserDefaultsService.albumTitle
+        let trackingStartDate = UserDefaultsService.trackingStartDate
+        return Record(title: albumTitle, trackingStartDate: trackingStartDate)
     }
 }

--- a/poporazzi/UIComponent/LineTextField.swift
+++ b/poporazzi/UIComponent/LineTextField.swift
@@ -53,12 +53,15 @@ extension LineTextField {
     
     enum Action {
         case setupInputAccessoryView(UIView)
+        case presentKeyboard
     }
     
     func action(_ action: Action) {
         switch action {
         case let .setupInputAccessoryView(view):
             textField.inputAccessoryView = view
+            
+        case .presentKeyboard:
             textField.becomeFirstResponder()
         }
     }

--- a/poporazzi/UIComponent/MomentRecordCell.swift
+++ b/poporazzi/UIComponent/MomentRecordCell.swift
@@ -17,7 +17,6 @@ final class MomentRecordCell: UICollectionViewCell {
     
     private let image: UIImageView = {
         let imageView = UIImageView()
-        imageView.backgroundColor = .lightGray
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         return imageView

--- a/poporazzi/Utility/Alert+.swift
+++ b/poporazzi/Utility/Alert+.swift
@@ -1,0 +1,52 @@
+//
+//  Alert+.swift
+//  poporazzi
+//
+//  Created by 김민준 on 4/9/25.
+//
+
+import UIKit
+import RxSwift
+
+extension UIViewController {
+    
+    /// Alert 액션 타입
+    enum AlertActionType {
+        case confirm
+        case cancel
+    }
+    
+    /// Alert를 출력합니다.
+    func showAlert(
+        title: String,
+        message: String?,
+        confirmTitle: String
+    ) -> Observable<AlertActionType> {
+        return Observable.create { [weak self] observer in
+            let alert = UIAlertController(
+                title: title,
+                message: message,
+                preferredStyle: .alert
+            )
+            
+            let action = UIAlertAction(title: confirmTitle, style: .default) { _ in
+                observer.onNext(.confirm)
+                observer.onCompleted()
+            }
+            alert.addAction(action)
+            
+            let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
+                observer.onNext(.cancel)
+                observer.onCompleted()
+            }
+            alert.addAction(cancelAction)
+            
+            self?.present(alert, animated: true)
+            
+            return Disposables.create {
+                alert.dismiss(animated: true)
+            }
+        }
+        .subscribe(on: MainScheduler.instance)
+    }
+}

--- a/poporazzi/Utility/Alert+.swift
+++ b/poporazzi/Utility/Alert+.swift
@@ -20,7 +20,8 @@ extension UIViewController {
     func showAlert(
         title: String,
         message: String?,
-        confirmTitle: String
+        confirmTitle: String,
+        isContainCancel: Bool = true
     ) -> Observable<AlertActionType> {
         return Observable.create { [weak self] observer in
             let alert = UIAlertController(
@@ -35,11 +36,13 @@ extension UIViewController {
             }
             alert.addAction(action)
             
-            let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
-                observer.onNext(.cancel)
-                observer.onCompleted()
+            if isContainCancel {
+                let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
+                    observer.onNext(.cancel)
+                    observer.onCompleted()
+                }
+                alert.addAction(cancelAction)
             }
-            alert.addAction(cancelAction)
             
             self?.present(alert, animated: true)
             

--- a/poporazzi/Utility/Formatter+.swift
+++ b/poporazzi/Utility/Formatter+.swift
@@ -1,0 +1,26 @@
+//
+//  Formatter+.swift
+//  poporazzi
+//
+//  Created by 김민준 on 4/8/25.
+//
+
+import Foundation
+
+// MARK: - Date
+
+extension Date {
+    
+    /// 공용 DateFormatter
+    static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter
+    }()
+    
+    /// 시작 날짜 포맷을 반환합니다.
+    var startDateFormat: String {
+        Date.dateFormatter.dateFormat = "yyyy년 m월 d일 E요일 H시 m분 ~"
+        return Date.dateFormatter.string(from: self)
+    }
+}

--- a/poporazzi/Utility/LineSpacing+.swift
+++ b/poporazzi/Utility/LineSpacing+.swift
@@ -1,0 +1,26 @@
+//
+//  LineSpacing+.swift
+//  poporazzi
+//
+//  Created by 김민준 on 4/9/25.
+//
+
+import UIKit
+
+extension UILabel {
+    
+    /// Label 정렬 및 줄 간격을 설정합니다.
+    func setLine(alignment: NSTextAlignment, spacing: CGFloat) {
+        guard let text = text else { return }
+        let attributeString = NSMutableAttributedString(string: text)
+        let style = NSMutableParagraphStyle()
+        style.alignment = alignment
+        style.lineSpacing = spacing
+        attributeString.addAttribute(
+            .paragraphStyle,
+            value: style,
+            range: NSRange(location: 0, length: attributeString.length)
+        )
+        attributedText = attributeString
+    }
+}


### PR DESCRIPTION
close #14

## *⛳️ Work Description*
- 앨범 제목 입력, 기록 화면 Flow 연결
- 기록 종료 Alert 추가
- 화면 진입 시 앨범 리스트 업데이트

## *🧐 트러블슈팅*
### 1. markDirty 함수를 이용한 레이아웃 업데이트
기존의 countLabel은 가로 사이즈가 고정되어 텍스트가 잘리는 현상이 발생했습니다. 이를 해결하기 위해 flexLayout의 `makeDirty` 함수 및 `layout` 함수를 이용해 View를 업데이트해주었습니다.
~~~swift
enum Action {
    case setAlbumTitleLabel(String)
    case setTrackingStartDateLabel(String)
    case setTotalImageCountLabel(Int)
}
func action(_ action: Action) {
    defer { containerView.flex.layout() } // ⭐️ 마지막에 layout 업데이트
    switch action {
    case let .setAlbumTitleLabel(title):
        albumTitleLabel.text = title
        albumTitleLabel.flex.markDirty() // ⭐️ item의 사이즈가 변경되었음을 알림
        
    case let .setTrackingStartDateLabel(text):
        trackingStartDateLabel.text = text
        trackingStartDateLabel.flex.markDirty() // ⭐️ item의 사이즈가 변경되었음을 알림
        
    case let .setTotalImageCountLabel(count):
        totalPhotoCountLabel.text = "총 \(count)개"
        totalPhotoCountLabel.flex.markDirty() // ⭐️ item의 사이즈가 변경되었음을 알림
        emptyLabel.flex.display(count > 0 ? .none : .flex)
    }
}
~~~

### 2. Photo 리스트 로딩 중 Hang 해결
기존의 PhotoKit을 이용한 Photo 리스트 반환 함수는 메인스레드에서 동작해 Hang이 감지되었습니다. 이를 해결하기 위해 RxSwift의 `observe(on:)` operator를 사용해 스레드를 전환해 해결했습니다.
~~~swift
/// ViewModel
updateRecord
    .observe(on: ConcurrentDispatchQueueScheduler(qos: .default)) // ⭐️ 백그라운드 스레드
    .withUnretained(self)
    .flatMap { owner, _ in owner.fetchCurrentPhotos() }
    .bind(to: output.photoList)
    .disposed(by: disposeBag)

/// ViewController
output.photoList
    .observe(on: MainScheduler.instance) // ⭐️ 메인 스레드
    .bind(to: screen.albumCollectionView.rx.items(
        cellIdentifier: MomentRecordCell.identifier,
        cellType: MomentRecordCell.self
    )) { [weak self] index, photo, cell in
        cell.action(.setImage(photo.content))
        self?.screen.albumCollectionView.refreshControl?.endRefreshing()
    }
    .disposed(by: disposeBag)
output.photoList
    .observe(on: MainScheduler.instance)
    .bind(with: self) { owner, photos in
        owner.screen.action(.setTotalImageCountLabel(photos.count))
        owner.screen.albumCollectionView.refreshControl?.endRefreshing()
    }
    .disposed(by: disposeBag)
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|empty 케이스|<img width="300" alt="" src="https://github.com/user-attachments/assets/d093addf-6fcc-4db4-9b78-f5ac1bbc4445">|
|종료 Alert|<img width="300" alt="" src="https://github.com/user-attachments/assets/4e6ca81e-ca8e-4632-8ca8-9a5e2119ba76">|