### PR TITLE
Input & Output 패턴 리팩토링

### DIFF
--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
@@ -11,12 +11,12 @@ import RxCocoa
 
 final class MomentTitleInputViewController: ViewController {
     
-    private let screen = MomentTitleInputView()
+    private let scene = MomentTitleInputView()
     private let viewModel = MomentTitleInputViewModel()
     private let disposeBag = DisposeBag()
     
     override func loadView() {
-        view = screen
+        view = scene
     }
     
     override func viewDidLoad() {
@@ -26,7 +26,7 @@ final class MomentTitleInputViewController: ViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        screen.titleTextField.action(.presentKeyboard)
+        scene.titleTextField.action(.presentKeyboard)
     }
 }
 
@@ -35,29 +35,38 @@ final class MomentTitleInputViewController: ViewController {
 extension MomentTitleInputViewController {
     
     func bind() {
-        let output = viewModel.transform(
-            MomentTitleInputViewModel.Input(
-                titleTextFieldDidChange: screen.titleTextField.textField
-                    .rx.text.orEmpty.asObservable(),
-                actionButtonTapped: screen.actionButton.button
-                    .rx.tap.asObservable()
-            )
+        let input = MomentTitleInputViewModel.Input(
+            titleTextChanged:
+                scene.titleTextField.textField.rx.text.orEmpty.asSignal(onErrorJustReturn: ""),
+            startButtonTapped:
+                scene.actionButton.button.rx.tap.asSignal()
         )
+        let output = viewModel.transform(input)
         
-        output.actionButtonIsEnabled
-            .bind(with: self, onNext: { owner, isEnabled in
-                owner.screen.actionButton.action(.toggleEnabled(isEnabled))
-            })
+        output.isStartButtonEnabled
+            .emit(with: self) { owner, isEnabled in
+                owner.scene.actionButton.action(.toggleEnabled(isEnabled))
+            }
             .disposed(by: disposeBag)
         
-        output.navigateToRecordView
-            .bind(with: self, onNext: { owner, title in
-                owner.screen.titleTextField.textField.text?.removeAll()
-                let momentRecordVC = MomentRecordViewController()
-                momentRecordVC.modalPresentationStyle = .fullScreen
-                momentRecordVC.modalTransitionStyle = .crossDissolve
-                owner.present(momentRecordVC, animated: true)
-            })
+        output.didNavigateToRecord
+            .emit(with: self) { owner, _ in
+                owner.scene.titleTextField.textField.text = ""
+                owner.presentMomentRecord()
+            }
             .disposed(by: disposeBag)
+    }
+}
+
+// MARK: - Navigation
+
+extension MomentTitleInputViewController {
+    
+    /// 기록 화면을 출력합니다.
+    private func presentMomentRecord() {
+        let momentRecordVC = MomentRecordViewController()
+        momentRecordVC.modalPresentationStyle = .fullScreen
+        momentRecordVC.modalTransitionStyle = .crossDissolve
+        self.present(momentRecordVC, animated: true)
     }
 }

--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewController.swift
@@ -36,10 +36,8 @@ extension MomentTitleInputViewController {
     
     func bind() {
         let input = MomentTitleInputViewModel.Input(
-            titleTextChanged:
-                scene.titleTextField.textField.rx.text.orEmpty.asSignal(onErrorJustReturn: ""),
-            startButtonTapped:
-                scene.actionButton.button.rx.tap.asSignal()
+            titleTextChanged: scene.titleTextField.textField.rx.text.orEmpty.asSignal(onErrorJustReturn: ""),
+            startButtonTapped:scene.actionButton.button.rx.tap.asSignal()
         )
         let output = viewModel.transform(input)
         

--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
@@ -26,7 +26,7 @@ final class MomentTitleInputViewModel: ViewModel {
     
     private let titleText = BehaviorRelay<String>(value: "")
     private let isStartButtonEnabled = PublishRelay<Bool>()
-    private let didNavigateToRecord = PublishRelay<Void>()
+    private let navigateToRecord = PublishRelay<Void>()
 }
 
 // MARK: - Transform
@@ -48,14 +48,14 @@ extension MomentTitleInputViewModel {
                 UserDefaultsService.isTracking = true
                 UserDefaultsService.albumTitle = owner.titleText.value
                 UserDefaultsService.trackingStartDate = .now
-                owner.didNavigateToRecord.accept(())
+                owner.navigateToRecord.accept(())
             }
             .disposed(by: disposeBag)
         
         return Output(
             titleText: titleText.asSignal(onErrorJustReturn: ""),
             isStartButtonEnabled: isStartButtonEnabled.asSignal(),
-            didNavigateToRecord: didNavigateToRecord.asSignal()
+            didNavigateToRecord: navigateToRecord.asSignal()
         )
     }
 }

--- a/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
+++ b/poporazzi/Feature/1.MomentTitleInput/MomentTitleInputViewModel.swift
@@ -12,45 +12,50 @@ import RxCocoa
 final class MomentTitleInputViewModel: ViewModel {
     
     private let disposeBag = DisposeBag()
-}
-
-// MARK: - Input & Output
-
-extension MomentTitleInputViewModel {
     
     struct Input {
-        let titleTextFieldDidChange: Observable<String>
-        let actionButtonTapped: Observable<Void>
+        let titleTextChanged: Signal<String>
+        let startButtonTapped: Signal<Void>
     }
     
     struct Output {
-        let titleTextFieldText: PublishRelay<String> = .init()
-        let actionButtonIsEnabled: PublishRelay<Bool> = .init()
-        let navigateToRecordView: PublishRelay<String> = .init()
+        let titleText: Signal<String>
+        let isStartButtonEnabled: Signal<Bool>
+        let didNavigateToRecord: Signal<Void>
     }
     
+    private let titleText = BehaviorRelay<String>(value: "")
+    private let isStartButtonEnabled = PublishRelay<Bool>()
+    private let didNavigateToRecord = PublishRelay<Void>()
+}
+
+// MARK: - Transform
+
+extension MomentTitleInputViewModel {
+    
     func transform(_ input: Input) -> Output {
-        let output = Output()
-        
-        input.titleTextFieldDidChange
-            .bind(to: output.titleTextFieldText)
+        input.titleTextChanged
+            .emit(to: titleText)
             .disposed(by: disposeBag)
         
-        input.titleTextFieldDidChange
+        input.titleTextChanged
             .map { !$0.isEmpty }
-            .bind(to: output.actionButtonIsEnabled)
+            .emit(to: isStartButtonEnabled)
             .disposed(by: disposeBag)
         
-        input.actionButtonTapped
-            .withLatestFrom(output.titleTextFieldText)
-            .do {
+        input.startButtonTapped
+            .emit(with: self) { owner, _ in
                 UserDefaultsService.isTracking = true
-                UserDefaultsService.albumTitle = $0
+                UserDefaultsService.albumTitle = owner.titleText.value
                 UserDefaultsService.trackingStartDate = .now
+                owner.didNavigateToRecord.accept(())
             }
-            .bind(to: output.navigateToRecordView)
             .disposed(by: disposeBag)
         
-        return output
+        return Output(
+            titleText: titleText.asSignal(onErrorJustReturn: ""),
+            isStartButtonEnabled: isStartButtonEnabled.asSignal(),
+            didNavigateToRecord: didNavigateToRecord.asSignal()
+        )
     }
 }

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
@@ -13,8 +13,8 @@ import Photos
 final class MomentRecordViewModel: ViewModel {
     
     private let photoKitService = PhotoKitService()
-    private let disposeBag = DisposeBag()
     private var fetchResult: PHFetchResult<PHAsset>?
+    private let disposeBag = DisposeBag()
     
     let output = Output()
 }

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
@@ -31,12 +31,12 @@ final class MomentRecordViewModel: ViewModel {
         let navigateToHome: Signal<Void>
     }
     
-    struct AlertState {
+    struct AlertAction {
         let save = PublishRelay<Void>()
         let navigateToHome = PublishRelay<Void>()
     }
     
-    private let alert = AlertState()
+    private let alert = AlertAction()
     private let record = BehaviorRelay<Record>(value: .initialValue)
     private let photoList = BehaviorRelay<[Photo]>(value: [])
     private let finishAlertPresented = PublishRelay<Alert>()

--- a/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
+++ b/poporazzi/Feature/2.MomentRecord/MomentRecordViewModel.swift
@@ -12,75 +12,97 @@ import Photos
 
 final class MomentRecordViewModel: ViewModel {
     
+    private let disposeBag = DisposeBag()
     private let photoKitService = PhotoKitService()
     private var fetchResult: PHFetchResult<PHAsset>?
-    private let disposeBag = DisposeBag()
     
-    let output = Output()
+    struct Input {
+        let viewDidLoad: Signal<Void>
+        let viewBecomeActive: Signal<Notification>
+        let viewDidRefresh: Signal<Void>
+        let finishButtonTapped: Signal<Void>
+    }
+    
+    struct Output {
+        let record: Driver<Record>
+        let photoList: Driver<[Photo]>
+        let finishAlertPresented: Signal<Alert>
+        let saveCompleteAlertPresented: Signal<Alert>
+        let navigateToHome: Signal<Void>
+    }
+    
+    struct AlertState {
+        let save = PublishRelay<Void>()
+        let navigateToHome = PublishRelay<Void>()
+    }
+    
+    private let alert = AlertState()
+    private let record = BehaviorRelay<Record>(value: .initialValue)
+    private let photoList = BehaviorRelay<[Photo]>(value: [])
+    private let finishAlertPresented = PublishRelay<Alert>()
+    private let saveCompleteAlertPresented = PublishRelay<Alert>()
+    private let navigateToHome = PublishRelay<Void>()
 }
 
 // MARK: - Input & Output
 
 extension MomentRecordViewModel {
     
-    struct Input {
-        let viewDidLoad: Observable<Void>
-        let viewBecomeActive: Observable<Notification>
-        let refresh: Observable<Void>
-        let finishButtonTapped: Observable<Void>
-        let saveToAlbumButtonTapped: PublishRelay<Void>
-        let backToHomeButtonTapped: PublishRelay<Void>
-    }
-    
-    struct Output {
-        let currentRecord: BehaviorRelay<Record> = .init(value: .initialValue)
-        let photoList: BehaviorRelay<[Photo]> = .init(value: [])
-        let finishAlertPresented: PublishRelay<Void> = .init()
-        let saveToAlbum: PublishRelay<Void> = .init()
-        let backToHome: PublishRelay<Void> = .init()
-    }
-    
     func transform(_ input: Input) -> Output {
-        let updateRecord = Observable.merge(
+        let updateRecord = Signal.merge(
             input.viewDidLoad,
-            input.refresh,
+            input.viewDidRefresh,
             input.viewBecomeActive.map { _ in }
         )
         
         updateRecord
             .withUnretained(self)
             .map { owner, _ in owner.currentRecord() }
-            .bind(to: output.currentRecord)
+            .emit(to: record)
             .disposed(by: disposeBag)
         
         updateRecord
-            .observe(on: ConcurrentDispatchQueueScheduler(qos: .default))
+            .asObservable()
+            .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
             .withUnretained(self)
             .flatMap { owner, _ in owner.fetchCurrentPhotos() }
-            .bind(to: output.photoList)
+            .bind(to: photoList)
             .disposed(by: disposeBag)
         
         input.finishButtonTapped
-            .bind(to: output.finishAlertPresented)
+            .emit(with: self) { owner, _ in
+                owner.finishAlertPresented.accept(owner.finishAlert)
+            }
             .disposed(by: disposeBag)
         
-        input.saveToAlbumButtonTapped
-            .do(onNext: { [weak self] _ in
-                let title = UserDefaultsService.albumTitle
-                try self?.photoKitService.saveAlbum(title: title, assets: self?.fetchResult)
-            })
-            .bind(to: output.saveToAlbum)
+        alert.save
+            .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
+            .bind(with: self) { owner, _ in
+                do {
+                    try owner.saveToAlbums()
+                    owner.saveCompleteAlertPresented.accept(owner.saveAlert)
+                } catch {
+                    print(error)
+                }
+            }
             .disposed(by: disposeBag)
         
-        input.backToHomeButtonTapped
-            .bind(to: output.backToHome)
+        alert.navigateToHome
+            .do { _ in UserDefaultsService.isTracking = false }
+            .bind(to: navigateToHome)
             .disposed(by: disposeBag)
         
-        return output
+        return Output(
+            record: record.asDriver(),
+            photoList: photoList.asDriver(),
+            finishAlertPresented: finishAlertPresented.asSignal(),
+            saveCompleteAlertPresented: saveCompleteAlertPresented.asSignal(),
+            navigateToHome: navigateToHome.asSignal()
+        )
     }
 }
 
-// MARK: - Helper
+// MARK: - Logic
 
 extension MomentRecordViewModel {
     
@@ -100,5 +122,37 @@ extension MomentRecordViewModel {
             ascending: true
         )
         return photoKitService.fetchPhotos(fetchResult)
+    }
+    
+    /// 앨범에 저장합니다.
+    private func saveToAlbums() throws {
+        let title = UserDefaultsService.albumTitle
+        try photoKitService.saveAlbum(title: title, assets: fetchResult)
+    }
+}
+
+// MARK: - Alert
+
+extension MomentRecordViewModel {
+    
+    /// 기록 종료 Alert
+    private var finishAlert: Alert {
+        let title = UserDefaultsService.albumTitle
+        let totalCount = photoList.value.count
+        return Alert(
+            title: "기록을 종료합니다.",
+            message: "총 \(totalCount)장의 '\(title)' 기록이 종료돼요",
+            eventButton: .init(title: "종료", action: alert.save),
+            cancelButton: .init(title: "취소")
+        )
+    }
+    
+    /// 앨범 저장 Alert
+    private var saveAlert: Alert {
+        Alert(
+            title: "기록이 앨범에 저장되었습니다.",
+            message: "앨범 앱을 확인해주세요!",
+            eventButton: .init(title: "홈으로 돌아가기", action: alert.navigateToHome)
+        )
     }
 }

--- a/poporazzi/Utility/Alert+.swift
+++ b/poporazzi/Utility/Alert+.swift
@@ -7,49 +7,63 @@
 
 import UIKit
 import RxSwift
+import RxCocoa
+
+/// Alert 타입
+struct Alert {
+    let title: String
+    let message: String?
+    let eventButton: AlertButton
+    let cancelButton: AlertButton?
+    
+    init(
+        title: String,
+        message: String? = nil,
+        eventButton: AlertButton,
+        cancelButton: AlertButton? = nil
+    ) {
+        self.title = title
+        self.message = message
+        self.eventButton = eventButton
+        self.cancelButton = cancelButton
+    }
+}
+
+/// Alert 버튼
+struct AlertButton {
+    let title: String
+    let action: PublishRelay<Void>?
+    
+    init(title: String, action: PublishRelay<Void>? = nil) {
+        self.title = title
+        self.action = action
+    }
+}
+
+// MARK: - Alert Helper
 
 extension UIViewController {
     
-    /// Alert 액션 타입
-    enum AlertActionType {
-        case confirm
-        case cancel
-    }
-    
     /// Alert를 출력합니다.
-    func showAlert(
-        title: String,
-        message: String?,
-        confirmTitle: String,
-        isContainCancel: Bool = true
-    ) -> Observable<AlertActionType> {
-        return Observable.create { [weak self] observer in
-            let alert = UIAlertController(
-                title: title,
-                message: message,
-                preferredStyle: .alert
-            )
-            
-            let action = UIAlertAction(title: confirmTitle, style: .default) { _ in
-                observer.onNext(.confirm)
-                observer.onCompleted()
-            }
-            alert.addAction(action)
-            
-            if isContainCancel {
-                let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
-                    observer.onNext(.cancel)
-                    observer.onCompleted()
-                }
-                alert.addAction(cancelAction)
-            }
-            
-            self?.present(alert, animated: true)
-            
-            return Disposables.create {
-                alert.dismiss(animated: true)
-            }
+    func showAlert(_ alert: Alert) {
+        let alertController = UIAlertController(
+            title: alert.title,
+            message: alert.message,
+            preferredStyle: .alert
+        )
+        
+        let action = UIAlertAction(title: alert.eventButton.title, style: .default) { _ in
+            alert.eventButton.action?.accept(())
         }
-        .subscribe(on: MainScheduler.instance)
+        alertController.addAction(action)
+        
+        if let cancelButton = alert.cancelButton {
+            let cancelAction = UIAlertAction(title: cancelButton.title, style: .cancel) { _ in
+                cancelButton.action?.accept(())
+            }
+            alertController.addAction(cancelAction)
+        }
+        
+        self.present(alertController, animated: true)
     }
 }

--- a/poporazzi/Utility/Notification+.swift
+++ b/poporazzi/Utility/Notification+.swift
@@ -1,0 +1,21 @@
+//
+//  Notification+.swift
+//  poporazzi
+//
+//  Created by 김민준 on 4/16/25.
+//
+
+import UIKit
+import RxCocoa
+
+extension Notification {
+    
+    /// 앱이 활성화되면 게시되는 알림 Signal입니다.
+    static var didBecomeActive: Signal<Notification> {
+        let didBecomeActiveNotification = UIApplication.didBecomeActiveNotification
+        return NotificationCenter.default
+            .rx.notification(didBecomeActiveNotification).asSignal(
+                onErrorJustReturn: .init(name: didBecomeActiveNotification)
+            )
+    }
+}


### PR DESCRIPTION
close #23 

## *⛳️ Work Description*
- MomentTitleInput, MomentRecord ViewModel, ViewController 리팩토링
- Alert 출력 로직 수정

## *🧐 트러블슈팅*
### 0. ViewModel 리팩토링의 목적
기존에 구현한 ViewModel의 역할이 불분명하다고 판단해 리팩토링을 진행했습니다. ViewController는 UI를 업데이트하고 생명주기를 관리하는 역할을, ViewModel은 비즈니스 로직을 포함 및 상태 관리의 역할을 강화하기 위한 리팩토링이었습니다. 또한 추후 생산성 향상을 위한 컨벤션 확립, 유닛 테스트를 위한 초석이기도 합니다.

### 1. Input & Output의 MainThread에서의 동작을 보장하기 위한 `Signal`, `Driver` 사용
- 기존 Input & Output은 메인 스레드에서 동작을 보장해주지 않았기 때문에 Concurrency Queue 사용 이후에는 신경써서 메인스레드로 돌아올 수 있도록 구현해주어야했습니다. 이는 개발자의 실수를 야기할 수 있음을 의미합니다.
- Input은 모두 메인스레드에서 동작하고, 상태가 없으므로, `Signal`로 통일이 가능합니다.
- Output 역시 UI에 바인딩 되어야 하므로 메인스레드에서의 동작을 보장해주어야 합니다. 이벤트 작업(한 번 발생하고 처리해야 하는 이벤트)에는 `Signal`을, 상태 바인딩(지속적으로 관찰하고 UI에 바인딩)이 필요한 경우 `Driver`를 사용합니다.
- 네이밍의 경우 Input은 명확한 이벤트 액션을 동사로, Output은 상태의 경우 명사를, 이벤트 액션은 동사로 작성했습니다.

#### Before
~~~swift
struct Input {
    let viewDidLoad: Observable<Void>
    let viewBecomeActive: Observable<Notification>
    let refresh: Observable<Void>
    let finishButtonTapped: Observable<Void>
    let saveToAlbumButtonTapped: PublishRelay<Void>
    let backToHomeButtonTapped: PublishRelay<Void>
}

struct Output {
    let currentRecord: BehaviorRelay<Record> = .init(value: .initialValue)
    let photoList: BehaviorRelay<[Photo]> = .init(value: [])
    let finishAlertPresented: PublishRelay<Void> = .init()
    let saveToAlbum: PublishRelay<Void> = .init()
    let backToHome: PublishRelay<Void> = .init()
}
~~~

#### After
~~~swift
//  ⭐️ Input은 Signal로 통일 가능
struct Input {
    let viewDidLoad: Signal<Void>
    let viewBecomeActive: Signal<Notification>
    let viewDidRefresh: Signal<Void>
    let finishButtonTapped: Signal<Void>
}

struct Output {
    let record: Driver<Record> //  ⭐️ 상태 바인딩은 Driver
    let photoList: Driver<[Photo]>
    let finishAlertPresented: Signal<Alert> //  ⭐️ 이벤트 바인딩은 Signal
    let saveCompleteAlertPresented: Signal<Alert>
    let navigateToHome: Signal<Void>
}
~~~

### 2. ViewModel 내부 값 저장 및 발행을 위한 `PublishRelay`, `BehaviorRelay` 사용
- ViewModel 내부 로직 처리를 위해 직접 이벤트 발행 및 상태값(record, photoList 등)의 사용이 필요했습니다. 하지만 Signal과 Driver는 UI 바인딩에 특화되어 있기 때문에 이벤트를 직접 발행하거나, 마지막 값을 받아오기에 적합하지 않았습니다. 이를 해결하기 위해 ViewModel 내부에서만 사용하는 Output과 동일한 모양의 `PublishRelay`, `BehaviorRelay` 인스턴스를 생성해 활용했습니다.
- 기존 Output은 모두 `PublishRelay`와 `BehaviorRelay`를 사용하고 있었기 때문에 문제가 없었지만, 메인 스레드 동작을 보장 + UI 바인딩 최적화를 위해 `Signal`과 `Driver`를 사용함으로써 구현이 필요했습니다.

~~~swift
struct Output {
    let record: Driver<Record>
    let photoList: Driver<[Photo]>
    let finishAlertPresented: Signal<Alert>
    let saveCompleteAlertPresented: Signal<Alert>
    let navigateToHome: Signal<Void>
}

private let record = BehaviorRelay<Record>(value: .initialValue)
private let photoList = BehaviorRelay<[Photo]>(value: [])
private let finishAlertPresented = PublishRelay<Alert>()
private let saveCompleteAlertPresented = PublishRelay<Alert>()
private let navigateToHome = PublishRelay<Void>()
~~~

### 3. ViewModel 내부에서 Alert 로직 처리
- 기존에는 Alert 표현을 위한 상태, 이벤트 발행을 위해 ViewController가 ViewModel에 직접 접근해 구현하는 방식이었습니다. 이는, ViewModel 내부에서 상태 및 이벤트 바인딩 로직을 작성하는 흐름과 상반되어 일관된 구현을 어렵게 만들었습니다.
- 이를 해결하기 위해, ViewModel 내부 Alert 전용 액션인 `AlertAction`을 구현하고, `Alert` 구조체를 반환하는 이벤트를 방출해 ViewController에서는 Alert를 출력하는 로직만 작성할 수 있도록, 이외의 로직은 ViewModel에서 작성할 수 있도록 보장했습니다.

#### Before
~~~swift
/// MomentRecordViewController.swift
private func showFinishAlert() {
    let title = UserDefaultsService.albumTitle
    let totalCount = viewModel.output.photoList.value.count //  ⭐️ 기존에는 ViewModel 내부 Output에 접근해 상태를 꺼내오고 있었음.
    showAlert(
        title: "기록을 종료합니다",
        message: "총 \(totalCount)장의 '\(title)' 기록이 종료돼요",
        confirmTitle: "종료"
    )
    .subscribe { actionType in
        switch actionType {
        case .cancel:
            break
        case .confirm:
            self.input.saveToAlbumButtonTapped.accept(()) //  ⭐️ 또한 이벤트 발행 시점을 Input 생성 시에 할 수 없기 때문에 추가 구현을 통해 신경써주어야 했음.
        }
    }
    .disposed(by: disposeBag)
}
~~~

#### After
~~~swift
/// MomentRecordViewModel.swift
//  ⭐️ Alert 내부 액션을 정의
struct AlertAction {
    let save = PublishRelay<Void>() //  ⭐️ 값을 직접 발행하기 위한 Relay 사용
    let navigateToHome = PublishRelay<Void>()
}

private let alert = AlertState() //  ⭐️ 전역적으로 사용할 인스턴스 생성

func transform(_ input: Input) -> Output {
   
    // ...
 
    input.finishButtonTapped
        .emit(with: self) { owner, _ in
            owner.finishAlertPresented.accept(owner.finishAlert) //  ⭐️ Alert 이벤트 발행, VC에서 받아서 출력하고 있음.
        }
        .disposed(by: disposeBag)
    
    //  ⭐️ Alert 내부 저장을 눌렀을 때 실행할 동작 바인딩
    alert.save
        .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
        .bind(with: self) { owner, _ in
            do {
                try owner.saveToAlbums()
                owner.saveCompleteAlertPresented.accept(owner.saveAlert)
            } catch {
                print(error)
            }
        }
        .disposed(by: disposeBag)

    // ...
}

/// 기록 종료 Alert
private var finishAlert: Alert {
    let title = UserDefaultsService.albumTitle
    let totalCount = photoList.value.count
    return Alert(
        title: "기록을 종료합니다.",
        message: "총 \(totalCount)장의 '\(title)' 기록이 종료돼요",
        eventButton: .init(title: "종료", action: alert.save),
        cancelButton: .init(title: "취소")
    )
}
~~~