### PR TITLE
기록한 사진이 없을 때 종료 케이스 추가

### DIFF
--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -21,7 +21,6 @@ struct PhotoKitService {
     /// PhotoKit에서 발생할 수 있는 에러
     enum PhotoKitError: Error {
         case emptyAssets
-        case cannotFindAlbum
     }
 }
 

--- a/poporazzi/Feature/2.Record/RecordViewController.swift
+++ b/poporazzi/Feature/2.Record/RecordViewController.swift
@@ -72,13 +72,7 @@ extension RecordViewController {
             }
             .disposed(by: disposeBag)
         
-        output.finishAlertPresented
-            .bind(with: self) { owner, alert in
-                owner.showAlert(alert)
-            }
-            .disposed(by: disposeBag)
-        
-        output.saveCompleteAlertPresented
+        output.alertPresented
             .bind(with: self) { owner, alert in
                 owner.showAlert(alert)
             }


### PR DESCRIPTION
close #40

## *⛳️ Work Description*
- 현재 촬영한 기록이 없을 때 케이스 추가

## *🧐 트러블슈팅*
~~~swift
alert
    .bind(with: self) { owner, action in
        switch action {
        case .save:
            // ⭐️ MediaList가 있는지 없는지를 검사 후 반환
            if owner.output.mediaList.value.isEmpty {
                owner.navigation.accept(.pop)
                UserDefaultsService.isTracking = false
            } else {
                // ⭐️ 요 에러 처리는 나중에 PhotoKitService 구현에 따라 처리 예정
                try? owner.saveToAlbums()
                owner.output.alertPresented.accept(owner.saveCompleteAlert)
            }
            
        case .popToHome:
            owner.navigation.accept(.pop)
            UserDefaultsService.isTracking = false
        }
    }
    .disposed(by: disposeBag)
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|기록 없을 경우 Alert|<img width="300" alt="" src="https://github.com/user-attachments/assets/2681cf8c-8b9f-4a78-a2e7-9f49c645552a">|

