### PR TITLE
DI Container 구현

### DIFF
--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -13,7 +13,6 @@ final class Coordinator {
     
     private var window: UIWindow?
     private var navigationController = UINavigationController()
-    private let disposeBag = DisposeBag()
     
     init(window: UIWindow?) {
         self.window = window
@@ -21,6 +20,7 @@ final class Coordinator {
     
     /// 진입 화면을 설정합니다.
     func start() {
+        DIContainer.shared.injectDependencies()
         let titleInputVM = TitleInputViewModel(output: .init())
         let titleInputVC = TitleInputViewController(viewModel: titleInputVM)
         navigationController = UINavigationController(rootViewController: titleInputVC)
@@ -33,7 +33,7 @@ final class Coordinator {
                     owner.pushRecord(titleInputVM, record)
                 }
             }
-            .disposed(by: disposeBag)
+            .disposed(by: titleInputVC.disposeBag)
         
         if UserDefaultsService.isTracking {
             let record = UserDefaultsService.record

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -20,7 +20,6 @@ final class Coordinator {
     
     /// 진입 화면을 설정합니다.
     func start() {
-        DIContainer.shared.injectDependencies()
         let titleInputVM = TitleInputViewModel(output: .init())
         let titleInputVC = TitleInputViewController(viewModel: titleInputVM)
         navigationController = UINavigationController(rootViewController: titleInputVC)

--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -16,7 +16,8 @@ final class DIContainer {
     
     /// 객체를 등록합니다.
     func register<T>(_ dependency: T) {
-        dependencies[key(from: dependency)] = dependency
+        let key = key(from: T.self)
+        dependencies[key] = dependency
     }
     
     /// 객체를 꺼내옵니다.
@@ -26,6 +27,17 @@ final class DIContainer {
             fatalError("\(key): 등록되지 않은 객체")
         }
         return dependency as! T
+    }
+}
+
+// MARK: - Injection
+
+extension DIContainer {
+    
+    /// 전체 의존성을 주입합니다.
+    func injectDependencies() {
+        register(LiveActivityService())
+        register(PhotoKitService())
     }
 }
 

--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -9,9 +9,11 @@ import Foundation
 
 final class DIContainer {
     
+    /// 싱글톤
     static let shared = DIContainer()
     private init() {}
     
+    /// 의존 객체를 담는 배열
     private var dependencies = [String: Any]()
     
     /// 객체를 등록합니다.

--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -1,0 +1,52 @@
+//
+//  DIContainer.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/2/25.
+//
+
+import Foundation
+
+final class DIContainer {
+    
+    static let shared = DIContainer()
+    private init() {}
+    
+    private var dependencies = [String: Any]()
+    
+    /// 객체를 등록합니다.
+    func register<T>(_ dependency: T) {
+        dependencies[key(from: dependency)] = dependency
+    }
+    
+    /// 객체를 꺼내옵니다.
+    func resolve<T>() -> T {
+        let key = key(from: T.self)
+        guard let dependency = dependencies[key] else {
+            fatalError("\(key): 등록되지 않은 객체")
+        }
+        return dependency as! T
+    }
+}
+
+// MARK: - Helper
+
+extension DIContainer {
+    
+    /// Dependency에 대한 Key를 생성합니다.
+    private func key<T>(from dependency: T) -> String {
+        String(describing: type(of: T.self))
+    }
+}
+
+// MARK: - PropertyWrapper
+
+@propertyWrapper
+final class Dependency<T> {
+    
+    let wrappedValue: T
+    
+    init() {
+        self.wrappedValue = DIContainer.shared.resolve()
+    }
+}

--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -13,43 +13,18 @@ final class DIContainer {
     static let shared = DIContainer()
     private init() {}
     
-    /// 의존 객체를 담는 배열
-    private var dependencies = [String: Any]()
+    /// 의존성이 담긴 객체
+    private let dependencies = Dependencies()
     
-    /// 객체를 등록합니다.
-    func register<T>(_ dependency: T) {
-        let key = key(from: T.self)
-        dependencies[key] = dependency
+    /// 의존성 리스트
+    final class Dependencies {
+        let liveActivityService = LiveActivityService()
+        let photoKitService = PhotoKitService()
     }
     
     /// 객체를 꺼내옵니다.
-    func resolve<T>() -> T {
-        let key = key(from: T.self)
-        guard let dependency = dependencies[key] else {
-            fatalError("\(key): 등록되지 않은 객체")
-        }
-        return dependency as! T
-    }
-}
-
-// MARK: - Injection
-
-extension DIContainer {
-    
-    /// 전체 의존성을 주입합니다.
-    func injectDependencies() {
-        register(LiveActivityService())
-        register(PhotoKitService())
-    }
-}
-
-// MARK: - Helper
-
-extension DIContainer {
-    
-    /// Dependency에 대한 Key를 생성합니다.
-    private func key<T>(from dependency: T) -> String {
-        String(describing: type(of: T.self))
+    fileprivate func resolve<T>(_ keyPath: KeyPath<Dependencies, T>) -> T {
+        dependencies[keyPath: keyPath]
     }
 }
 
@@ -60,7 +35,7 @@ final class Dependency<T> {
     
     let wrappedValue: T
     
-    init() {
-        self.wrappedValue = DIContainer.shared.resolve()
+    init(_ keyPath: KeyPath<DIContainer.Dependencies, T>) {
+        self.wrappedValue = DIContainer.shared.resolve(keyPath)
     }
 }

--- a/poporazzi/Data/Service/LiveActivityService.swift
+++ b/poporazzi/Data/Service/LiveActivityService.swift
@@ -10,9 +10,6 @@ import ActivityKit
 
 final class LiveActivityService {
     
-    static let shared = LiveActivityService()
-    private init() {}
-    
     private var activity: Activity<PoporazziWidgetAttributes>?
 }
 

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
@@ -13,7 +13,8 @@ final class TitleInputViewController: ViewController {
     
     private let scene = TitleInputView()
     private let viewModel: TitleInputViewModel
-    private let disposeBag = DisposeBag()
+    
+    let disposeBag = DisposeBag()
     
     init(viewModel: TitleInputViewModel) {
         self.viewModel = viewModel

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
@@ -11,7 +11,7 @@ import RxCocoa
 
 final class TitleInputViewModel: ViewModel {
     
-    private let liveActivityService = LiveActivityService.shared
+    @Dependency private var liveActivityService: LiveActivityService
     
     private let disposeBag = DisposeBag()
     private let output: Output

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
@@ -11,7 +11,7 @@ import RxCocoa
 
 final class TitleInputViewModel: ViewModel {
     
-    @Dependency private var liveActivityService: LiveActivityService
+    @Dependency(\.liveActivityService) private var liveActivityService
     
     private let disposeBag = DisposeBag()
     private let output: Output

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -11,8 +11,8 @@ import Photos
 
 final class RecordViewModel: ViewModel {
     
-    @Dependency private var liveActivityService: LiveActivityService
-    @Dependency private var photoKitService: PhotoKitService
+    @Dependency(\.liveActivityService) private var liveActivityService
+    @Dependency(\.photoKitService) private var photoKitService
     
     private var fetchResult: PHFetchResult<PHAsset>?
     

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -11,8 +11,9 @@ import Photos
 
 final class RecordViewModel: ViewModel {
     
-    private let liveActivityService = LiveActivityService.shared
-    private let photoKitService = PhotoKitService()
+    @Dependency private var liveActivityService: LiveActivityService
+    @Dependency private var photoKitService: PhotoKitService
+    
     private var fetchResult: PHFetchResult<PHAsset>?
     
     private let disposeBag = DisposeBag()


### PR DESCRIPTION
close #46

## *⛳️ Work Description*
- DI Container 구현
- ViewModel 내 Dependency 매크로를 이용한 객체 사용 전환

## *🧐 트러블슈팅*
### 1. DI Container 구현
객체 주입 시점 컨트롤, 객체 재사용 등의 문제를 해결하기 위해 DI Container를 구현했습니다. 
([DI Container 레퍼런스](https://eunjin3786.tistory.com/233)를 보고 참고했습니다!)

DI Container의 주요 포인트는 구현체를 생성한 프로퍼티에 특정 값을 통해 접근해 반환받는 것입니다. 임의의 Key를 생성해 받는 방법도 있지만, KeyPath를 이용하면 쉽고 안전하게 내부 프로퍼티에 접근할 수 있기에 해당 방식을 이용해 객체를 반환받습니다.
~~~swift
final class DIContainer {
    
    /// 싱글톤
    static let shared = DIContainer()
    private init() {}
    
    /// 의존성이 담긴 객체
    private let dependencies = Dependencies()
    
    /// 의존성 리스트
    final class Dependencies {
        let liveActivityService = LiveActivityService()
        let photoKitService = PhotoKitService()
    }
    
    /// 객체를 꺼내옵니다.
    fileprivate func resolve<T>(_ keyPath: KeyPath<Dependencies, T>) -> T {
        dependencies[keyPath: keyPath]
    }
}
~~~

사용은 아래와 같이 PropertyWrapper를 이용해 간결하게 반환이 가능합니다.
~~~swift
@propertyWrapper
final class Dependency<T> {
    
    let wrappedValue: T
    
    init(_ keyPath: KeyPath<DIContainer.Dependencies, T>) {
        self.wrappedValue = DIContainer.shared.resolve(keyPath)
    }
}

final class RecordViewModel: ViewModel {
    
    @Dependency(\.liveActivityService) private var liveActivityService
    @Dependency(\.photoKitService) private var photoKitService
}
~~~

여기서 Mock 객체 주입을 위해 각 서비스 객체를 추상화하는 방식을 고려했으나, 현재 단계에선 불필요하다고 느껴 작업을 마무리했습니다.