### PR TITLE
사진 라이브러리 변경에 따른 업데이트 기능 추가

### DIFF
--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -28,7 +28,7 @@ final class PhotoKitService: NSObject {
     private var fetchResult: PHFetchResult<PHAsset>?
     
     /// PhotoLibray의 변화가 감지할 때 이벤트를 발송하는 Relay
-    private let photoLibraryChangeRelay = PublishRelay<Void>()
+    private let photoLibraryChangeRelay = BehaviorRelay(value: ())
     
     override init() {
         super.init()
@@ -40,9 +40,9 @@ final class PhotoKitService: NSObject {
 
 extension PhotoKitService {
     
-    /// PhotoLibrayChangeRelay를 Observable로 반환
-    var photoLibraryChange: Observable<Void> {
-        photoLibraryChangeRelay.asObservable()
+    /// PhotoLibrayChangeRelay를 Signal로 반환
+    var photoLibraryChange: Signal<Void> {
+        photoLibraryChangeRelay.asSignal(onErrorJustReturn: ())
     }
     
     /// PhotoLibrary 권한을 요청합니다.

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -185,6 +185,18 @@ extension PhotoKitService: PHPhotoLibraryChangeObserver {
     
     /// PhotoLibrary의 변화 감지 시 호출됩니다.
     func photoLibraryDidChange(_ changeInstance: PHChange) {
+        guard let fetchResult,
+              let changeDetails = changeInstance.changeDetails(for: fetchResult) else {
+            return
+        }
         
+        /// 변화가 일어났는지 확인
+        if changeDetails.hasIncrementalChanges {
+            
+            // 추가 또는 삭제된 에셋이 있다면
+            if !changeDetails.insertedObjects.isEmpty || !changeDetails.removedObjects.isEmpty {
+                photoLibraryChangeRelay.accept(())
+            }
+        }
     }
 }

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -9,7 +9,7 @@ import UIKit
 import RxSwift
 import Photos
 
-struct PhotoKitService {
+final class PhotoKitService: NSObject {
     
     /// 미디어 검색 타입
     enum MediaFetchType {
@@ -21,6 +21,11 @@ struct PhotoKitService {
     /// PhotoKit에서 발생할 수 있는 에러
     enum PhotoKitError: Error {
         case emptyAssets
+    }
+    
+    override init() {
+        super.init()
+        PHPhotoLibrary.shared().register(self)
     }
 }
 
@@ -95,7 +100,8 @@ extension PhotoKitService {
         else {
             PHPhotoLibrary.shared().performChanges {
                 PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: title)
-            } completionHandler: { isSuccess, error in
+            } completionHandler: { [weak self] isSuccess, error in
+                guard let self else { return }
                 guard let album = fetchAlbum(title: title) else { return }
                 appendToAlbum(assets: assets, to: album)
             }
@@ -151,5 +157,15 @@ extension PhotoKitService {
             let request = PHAssetCollectionChangeRequest(for: album)
             request?.addAssets(assets)
         }
+    }
+}
+
+// MARK: - PHPhotoLibraryChangeObserver
+
+extension PhotoKitService: PHPhotoLibraryChangeObserver {
+    
+    /// PhotoLibrary의 변화 감지 시 호출됩니다.
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        print(changeInstance)
     }
 }

--- a/poporazzi/Feature/2.Record/RecordViewController.swift
+++ b/poporazzi/Feature/2.Record/RecordViewController.swift
@@ -42,7 +42,6 @@ extension RecordViewController {
     func bind() {
         let input = RecordViewModel.Input(
             viewDidLoad: .just(()),
-            viewBecomeActive: Notification.didBecomeActive,
             finishButtonTapped: scene.finishRecordButton.button.rx.tap.asSignal()
         )
         let output = viewModel.transform(input)

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -139,6 +139,12 @@ extension RecordViewModel {
             }
             .disposed(by: disposeBag)
         
+        photoKitService.photoLibraryChange
+            .bind(with: self) { owner, changeType in
+                print(changeType)
+            }
+            .disposed(by: disposeBag)
+        
         return output
     }
 }

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -36,7 +36,6 @@ extension RecordViewModel {
     
     struct Input {
         let viewDidLoad: Signal<Void>
-        let viewBecomeActive: Signal<Void>
         let finishButtonTapped: Signal<Void>
     }
     
@@ -78,7 +77,7 @@ extension RecordViewModel {
             }
             .disposed(by: disposeBag)
         
-        Signal.merge(input.viewBecomeActive, output.viewDidRefresh.asSignal())
+        Signal.merge(output.viewDidRefresh.asSignal(), photoKitService.photoLibraryChange)
             .asObservable()
             .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
             .withUnretained(self)
@@ -136,12 +135,6 @@ extension RecordViewModel {
                     owner.output.record.accept(record)
                     owner.output.viewDidRefresh.accept(())
                 }
-            }
-            .disposed(by: disposeBag)
-        
-        photoKitService.photoLibraryChange
-            .bind(with: self) { owner, changeType in
-                print(changeType)
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -7,14 +7,11 @@
 
 import RxSwift
 import RxCocoa
-import Photos
 
 final class RecordViewModel: ViewModel {
     
     @Dependency(\.liveActivityService) private var liveActivityService
     @Dependency(\.photoKitService) private var photoKitService
-    
-    private var fetchResult: PHFetchResult<PHAsset>?
     
     private let disposeBag = DisposeBag()
     private let output: Output
@@ -153,18 +150,13 @@ extension RecordViewModel {
     /// 현재 사진 리스트를 반환합니다.
     private func fetchCurrentPhotos() -> Observable<[Media]> {
         let trackingStartDate = output.record.value.trackingStartDate
-        fetchResult = photoKitService.fetchAssetResult(
-            mediaFetchType: .all,
-            date: trackingStartDate,
-            ascending: true
-        )
-        return photoKitService.fetchPhotos(fetchResult)
+        return photoKitService.fetchPhotos(date: trackingStartDate)
     }
     
     /// 앨범에 저장합니다.
     private func saveToAlbums() throws {
         let title = output.record.value.title
-        try photoKitService.saveAlbum(title: title, assets: fetchResult)
+        try photoKitService.saveAlbum(title: title)
     }
 }
 


### PR DESCRIPTION
close #48

## *⛳️ Work Description*
- 사진 라이브러리 변경에 따른 UI 및 LiveActivity 업데이트

## *🧐 트러블슈팅*
### 1. PhotoLibrary 변화 감지하기
PhotoLibrary에서는 `PHPhotoLibraryChangeObserver`를 제공합니다. 이는 사진 라이브러리의 변경 사항을 앱에 알리는데 사용할 수 있는 프로토콜로 사진 추가, 삭제, 업데이트 등의 변화를 감지할 수 있게됩니다.

이를 구현하기 위해 ViewController 내부에서 직접적으로 `PHPhotoLibraryChangeObserver`를 채택할 수도 있었지만 ViewController가 PhotoKit에 대한 의존성을 가졌을 때 추후 유지보수가 어려워질 수 있을 것으로 판단해 PhotoKitSerive 내부에 구현 후, Rx를 사용해 Stream을 보내주는 방식을 채택했습니다.

~~~swift
final class PhotoKitService: NSObject { /// ⭐️ PHPhotoLibraryChangeObserver를 채택하기 위한 NSObject 상속
    
    /// 가장 최근의 FetchResult를 저장하는 변수
    private var fetchResult: PHFetchResult<PHAsset>? /// ⭐️ 변화를 감지할 때 사용할 Result
    
    /// PhotoLibray의 변화가 감지할 때 이벤트를 발송하는 Relay
    private let photoLibraryChangeRelay = BehaviorRelay(value: ()) /// ⭐️ 이벤트 전달을 위한 Relay
    
    override init() {
        super.init()
        PHPhotoLibrary.shared().register(self) /// ⭐️ 생성과 동시에 변경 사항을 감지하기 위해 채택
    }
}

// MARK: - PHPhotoLibraryChangeObserver

extension PhotoKitService: PHPhotoLibraryChangeObserver { /// ⭐️ PHPhotoLibraryChangeObserver 채택
    
    /// PhotoLibrary의 변화 감지 시 호출됩니다.
    func photoLibraryDidChange(_ changeInstance: PHChange) {
        guard let fetchResult,
              let changeDetails = changeInstance.changeDetails(for: fetchResult) else {
            return
        }
        
        /// ⭐️ 변화가 일어났는지 확인
        if changeDetails.hasIncrementalChanges {
            
            // ⭐️ 추가 또는 삭제된 에셋이 있다면 이벤트 발송
            if !changeDetails.insertedObjects.isEmpty || !changeDetails.removedObjects.isEmpty {
                photoLibraryChangeRelay.accept(())
            }
        }
    }
}
~~~

~~~swift
/// RecordViewModel.swift
Signal.merge(output.viewDidRefresh.asSignal(), photoKitService.photoLibraryChange)
    .asObservable()
    .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
    .withUnretained(self)
    .flatMap { owner, _ in owner.fetchCurrentPhotos() }
    .bind(with: self) { owner, mediaList in
        owner.output.mediaList.accept(mediaList)
        owner.liveActivityService.update(
            albumTitle: owner.output.record.value.title,
            startDate: owner.output.record.value.trackingStartDate,
            totalCount: mediaList.count
        )
    }
    .disposed(by: disposeBag)
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|ex)로그인|<img width="300" alt="" src="">|
