### PR TITLE
1.3.0 배포

### DIFF
--- a/poporazzi.xcodeproj/project.pbxproj
+++ b/poporazzi.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2505041341;
+				CURRENT_PROJECT_VERSION = 2505071030;
 				DEVELOPMENT_TEAM = 9XG4S4XZWN;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = poporazzi/Info.plist;
@@ -375,7 +375,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.thinkyside.poporazzi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -394,7 +394,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2505041341;
+				CURRENT_PROJECT_VERSION = 2505071030;
 				DEVELOPMENT_TEAM = 9XG4S4XZWN;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = poporazzi/Info.plist;
@@ -411,7 +411,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.thinkyside.poporazzi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazzi.xcscheme
+++ b/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazzi.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8232593B2D9FBF4800CFC860"
+               BuildableName = "poporazzi.app"
+               BlueprintName = "poporazzi"
+               ReferencedContainer = "container:poporazzi.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8232593B2D9FBF4800CFC860"
+            BuildableName = "poporazzi.app"
+            BlueprintName = "poporazzi"
+            ReferencedContainer = "container:poporazzi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8232593B2D9FBF4800CFC860"
+            BuildableName = "poporazzi.app"
+            BlueprintName = "poporazzi"
+            ReferencedContainer = "container:poporazzi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazziWidgetExtension.xcscheme
+++ b/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazziWidgetExtension.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8221E3462DC3668F0092469D"
+               BuildableName = "poporazziWidgetExtension.appex"
+               BlueprintName = "poporazziWidgetExtension"
+               ReferencedContainer = "container:poporazzi.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8232593B2D9FBF4800CFC860"
+               BuildableName = "poporazzi.app"
+               BlueprintName = "poporazzi"
+               ReferencedContainer = "container:poporazzi.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8232593B2D9FBF4800CFC860"
+            BuildableName = "poporazzi.app"
+            BlueprintName = "poporazzi"
+            ReferencedContainer = "container:poporazzi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "timeline"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "systemMedium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8232593B2D9FBF4800CFC860"
+            BuildableName = "poporazzi.app"
+            BlueprintName = "poporazzi"
+            ReferencedContainer = "container:poporazzi.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -55,7 +55,7 @@ extension Coordinator {
         self.navigationController.pushViewController(recordVC, animated: true)
         
         recordVM.navigation
-            .bind(with: self) { owner, path in
+            .bind(with: self) { [weak recordVM] owner, path in
                 switch path {
                 case .pop:
                     owner.navigationController.popViewController(animated: true)
@@ -76,7 +76,7 @@ extension Coordinator {
 extension Coordinator {
     
     /// 앨범 수정 화면을 Present 합니다.
-    private func presentAlbumEdit(_ recordVM: RecordViewModel, _ album: Album) {
+    private func presentAlbumEdit(_ recordVM: RecordViewModel?, _ album: Album) {
         let editVM = AlbumEditViewModel(
             output: .init(
                 record: .init(value: album),
@@ -95,7 +95,7 @@ extension Coordinator {
                     owner.presentDatePickerModal(editVC, editVM, startDate: date)
                     
                 case .dismiss(let album):
-                    recordVM.delegate.accept(.albumDidEdited(album))
+                    recordVM?.delegate.accept(.albumDidEdited(album))
                     editVC?.dismiss(animated: true)
                 }
             }
@@ -103,7 +103,7 @@ extension Coordinator {
     }
     
     /// 제외된 기록 화면을 Present 합니다.
-    private func presentExcludeRecord(_ recordVM: RecordViewModel) {
+    private func presentExcludeRecord(_ recordVM: RecordViewModel?) {
         let excludeRecordVM = ExcludeRecordViewModel(output: .init())
         let excludeRecordVC = ExcludeRecordViewController(viewModel: excludeRecordVM)
         excludeRecordVC.modalPresentationStyle = .overFullScreen
@@ -113,7 +113,7 @@ extension Coordinator {
             .bind(with: self) { [weak excludeRecordVC] owner, path in
                 switch path {
                 case .dismiss:
-                    recordVM.delegate.accept(.updateExcludeRecord)
+                    recordVM?.delegate.accept(.updateExcludeRecord)
                     excludeRecordVC?.dismiss(animated: true)
                 }
             }

--- a/poporazzi/Data/Service/DeepLinkService.swift
+++ b/poporazzi/Data/Service/DeepLinkService.swift
@@ -1,0 +1,18 @@
+//
+//  DeepLinkService.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import UIKit
+
+struct DeepLinkService {
+    
+    /// 사진 앱의 앨범으로 딥링크합니다.
+    static func openPhotoAlbum() {
+        if let url = URL(string: "photos-navigation://album?name=recents") {
+            UIApplication.shared.open(url)
+        }
+    }
+}

--- a/poporazzi/Data/Service/HapticService.swift
+++ b/poporazzi/Data/Service/HapticService.swift
@@ -1,0 +1,21 @@
+//
+//  HapticService.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import UIKit
+
+enum HapticService {
+    
+    private static let notificationGenerator = UINotificationFeedbackGenerator()
+    
+    static func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        notificationGenerator.notificationOccurred(type)
+    }
+    
+    static func impact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        UIImpactFeedbackGenerator(style: style).impactOccurred()
+    }
+}

--- a/poporazzi/Feature/1.TitleInput/TitleInputView.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputView.swift
@@ -27,6 +27,15 @@ final class TitleInputView: CodeBaseUI {
     /// 제목 텍스트필드
     let titleTextField = LineTextField(size: 24, placeholder: "제주도 우정 여행, 성수동 데이트")
     
+    /// 제목 텍스트필드 보조 라벨
+    let titleTextFieldSubLabel: UILabel = {
+        let label = UILabel()
+        label.text = "앨범 제목은 언제든지 수정이 가능해요"
+        label.textColor = .subLabel
+        label.font = .setDovemayo(14)
+        return label
+    }()
+    
     /// 액션 버튼
     let actionButton = TextFieldActionButton(title: "기록 시작하기")
     
@@ -47,6 +56,26 @@ final class TitleInputView: CodeBaseUI {
     }
 }
 
+// MARK: - Action
+
+extension TitleInputView {
+    
+    enum Action {
+        case updateTitleTextFieldSubLabel
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case .updateTitleTextFieldSubLabel:
+            if let text = titleTextField.textField.text, !text.isEmpty {
+                titleTextFieldSubLabel.isHidden = true
+            } else {
+                titleTextFieldSubLabel.isHidden = false
+            }
+        }
+    }
+}
+
 // MARK: - Layout
 
 extension TitleInputView {
@@ -58,6 +87,7 @@ extension TitleInputView {
                 flex.addItem().direction(.column).paddingHorizontal(20).define { flex in
                     flex.addItem(headerLabel).marginTop(64)
                     flex.addItem(titleTextField).marginTop(32)
+                    flex.addItem(titleTextFieldSubLabel).marginTop(12)
                 }
             }
         

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
@@ -60,6 +60,7 @@ extension TitleInputViewController {
         scene.titleTextField.textField.rx.text
             .subscribe(with: self) { owner, _ in
                 owner.scene.titleTextField.action(.toggleLine)
+                owner.scene.action(.updateTitleTextFieldSubLabel)
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
@@ -75,6 +75,7 @@ extension TitleInputViewModel {
                     albumTitle: album.title,
                     startDate: album.trackingStartDate
                 )
+                HapticService.notification(type: .success)
                 UserDefaultsService.album = album
                 UserDefaultsService.isTracking = true
             }

--- a/poporazzi/Feature/2.Record/RecordView.swift
+++ b/poporazzi/Feature/2.Record/RecordView.swift
@@ -97,7 +97,7 @@ final class RecordView: CodeBaseUI {
     /// 촬영된 사진이 없을 때 라벨
     private let emptyLabel: UILabel = {
         let label = UILabel()
-        label.text = "지금부터 촬영한 모든 사진과\n영상이 기록될 거에요!"
+        label.text = "지금부터 촬영한 모든 사진과\n영상을 포포라치가 기록할 거에요!"
         label.numberOfLines = 3
         label.setLine(alignment: .center, spacing: 8)
         label.font = .setDovemayo(16)

--- a/poporazzi/Feature/2.Record/RecordViewController.swift
+++ b/poporazzi/Feature/2.Record/RecordViewController.swift
@@ -51,8 +51,8 @@ extension RecordViewController {
     /// DataSource를 설정합니다.
     private func setupDataSource() {
         dataSource = UICollectionViewDiffableDataSource<Section, Media>(collectionView: scene.recordCollectionView) {
-            (collectionView, indexPath, media) -> UICollectionViewCell? in
-            guard let cell = collectionView.dequeueReusableCell(
+            [weak self] (collectionView, indexPath, media) -> UICollectionViewCell? in
+            guard let self, let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: RecordCell.identifier,
                 for: indexPath
             ) as? RecordCell else { return nil }

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -101,9 +101,9 @@ extension RecordViewModel {
     
     /// 현재 청크를 기준으로 에셋 ID 배열을 반환합니다.
     private var chunkAssetIdentifiers: [String] {
-        let chunkStrart = min(currentChunk, output.mediaList.value.count)
-        let chunkEnd = min(chunkSize + chunkStrart, output.mediaList.value.count)
-        return output.mediaList.value[chunkStrart..<chunkEnd].map { $0.id }
+        let chunkStart = min(currentChunk, output.mediaList.value.count)
+        let chunkEnd = min(chunkSize + chunkStart, output.mediaList.value.count)
+        return output.mediaList.value[chunkStart..<chunkEnd].map { $0.id }
     }
     
     /// 다음 청크로 업데이트합니다.
@@ -134,7 +134,7 @@ extension RecordViewModel {
                 
                 let assetIdentifiers = owner.chunkAssetIdentifiers
                 owner.requestImages(from: assetIdentifiers)
-                    .bind(with: self) { owner, orderedMediaList in
+                    .bind { orderedMediaList in
                         owner.output.updateRecordCells.accept(orderedMediaList)
                     }
                     .disposed(by: owner.disposeBag)
@@ -154,7 +154,7 @@ extension RecordViewModel {
                     let assetIdentifiers = owner.chunkAssetIdentifiers
                     
                     owner.requestImages(from: assetIdentifiers)
-                        .bind(with: self) { owner, orderedMediaList in
+                        .bind { orderedMediaList in
                             let indexPathMediaList = orderedMediaList.map { (index, media) in
                                 OrderedMedia(
                                     index: owner.currentChunk + index,
@@ -179,7 +179,7 @@ extension RecordViewModel {
                 
                 let assetIdentifiers = owner.chunkAssetIdentifiers
                 owner.requestImages(from: assetIdentifiers)
-                    .bind(with: self) { owner, orderedMediaList in
+                    .bind { orderedMediaList in
                         owner.output.updateRecordCells.accept(orderedMediaList)
                     }
                     .disposed(by: owner.disposeBag)
@@ -284,7 +284,7 @@ extension RecordViewModel {
                     owner.output.toggleLoading.accept(true)
                     let assetIdentifiers = owner.selectedAssetIdentifiers()
                     owner.photoKitService.deletePhotos(from: assetIdentifiers)
-                        .bind(with: self) { owner, isSuccess in
+                        .bind { isSuccess in
                             if isSuccess {
                                 owner.output.selectedRecordCells.accept([])
                             } else {

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -250,6 +250,7 @@ extension RecordViewModel {
                     } else {
                         try? owner.saveToAlbums()
                         owner.output.alertPresented.accept(owner.saveCompleteAlert)
+                        HapticService.notification(type: .success)
                     }
                     
                     owner.liveActivityService.stop()

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -56,12 +56,7 @@ extension RecordViewModel {
     struct Output {
         let album: BehaviorRelay<Album>
         let mediaList = BehaviorRelay<[Media]>(value: [])
-        
-        let currentIndex = BehaviorRelay<[Int]>(value: [])
-        let totalIndexPaths = BehaviorRelay<[IndexPath]>(value: [])
-        
         let updateRecordCells = BehaviorRelay<[OrderedMedia]>(value: [])
-        
         let selectedRecordCells = BehaviorRelay<[IndexPath]>(value: [])
         let viewDidRefresh = PublishRelay<Void>()
         let setupSeeMoreMenu = BehaviorRelay<[MenuModel]>(value: [])

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 김민준 on 4/5/25.
 //
 
+import UIKit
 import Foundation
 import RxSwift
 import RxCocoa
@@ -79,6 +80,7 @@ extension RecordViewModel {
     
     enum AlertAction {
         case save
+        case linkToPhotoAlbum
         case popToHome
     }
     
@@ -256,6 +258,12 @@ extension RecordViewModel {
                     owner.liveActivityService.stop()
                     UserDefaultsService.isTracking = false
                     
+                case .linkToPhotoAlbum:
+                    DeepLinkService.openPhotoAlbum()
+                    owner.navigation.accept(.pop)
+                    UserDefaultsService.excludeAssets.removeAll()
+                    break
+                    
                 case .popToHome:
                     owner.navigation.accept(.pop)
                     UserDefaultsService.excludeAssets.removeAll()
@@ -366,7 +374,7 @@ extension RecordViewModel {
         let totalCount = output.mediaList.value.count
         let message = output.mediaList.value.isEmpty
         ? "촬영된 기록이 없어 앨범 저장 없이 종료돼요"
-        : "총 \(totalCount)장의 '\(title)' 기록이 종료 후 앨범에 저장돼요"
+        : "총 \(totalCount)장의 '\(title)' 기록이 종료 후 '사진' 앱 앨범에 저장돼요"
         return AlertModel(
             title: "기록을 종료할까요?",
             message: message,
@@ -385,8 +393,14 @@ extension RecordViewModel {
         let title = output.album.value.title
         return AlertModel(
             title: "기록이 종료되었습니다!",
-            message: "'\(title)' 앨범을 확인해보세요!",
+            message: "사진 앱 내 '\(title)' 앨범을 확인해보세요!",
             eventButton: .init(
+                title: "앨범 확인",
+                action: { [weak self] in
+                    self?.alertAction.accept(.linkToPhotoAlbum)
+                }
+            ),
+            cancelButton: .init(
                 title: "홈으로 돌아가기",
                 action: { [weak self] in
                     self?.alertAction.accept(.popToHome)

--- a/poporazzi/Feature/5.ExcludeRecord/ExcludeRecordViewModel.swift
+++ b/poporazzi/Feature/5.ExcludeRecord/ExcludeRecordViewModel.swift
@@ -138,7 +138,7 @@ extension ExcludeRecordViewModel {
                     owner.output.toggleLoading.accept(true)
                     let assetIdentifiers = owner.selectedAssetIdentifiers()
                     owner.photoKitService.deletePhotos(from: assetIdentifiers)
-                        .bind(with: self) { owner, isSuccess in
+                        .bind { isSuccess in
                             if isSuccess {
                                 UserDefaultsService.excludeAssets.removeAll { assetIdentifiers.contains($0) }
                                 owner.output.viewDidRefresh.accept(())


### PR DESCRIPTION
close #

## *⛳️ Work Description*
- ExcludeRecordView DiffableDataSource로 전환
- TitleView TextField SubLabel 추가
- 사진 앱 앨범 DeepLink 추가
- 전체 순환 참조 문제 해결

## *🧐 트러블슈팅*
### 1. 사진 앱 앨범 DeepLink 추가
iOS의 기본 '사진' 앱으로의 DeepLink는 공식적으로 공개된 값이 없습니다. 다만 리서치 중 우회적으로 사용 가능한 링크를 발견해 적용 후 사진 앱의 앨범 화면으로 딥링크할 수 있었습니다. 앱스토어 심사에서 리젝당하진 않았지만, 추후 삭제될 수도 있는 기능임을 염두에 두어야 합니다.
~~~swift
struct DeepLinkService {
    
    /// 사진 앱의 앨범으로 딥링크합니다.
    static func openPhotoAlbum() {
        if let url = URL(string: "photos-navigation://album?name=recents") {
            UIApplication.shared.open(url)
        }
    }
}
~~~

### 2. 전체 순환 참조 문제 해결
이전에 Log 함수를 각 ViewController와 ViewModel 내 deinit 될 때 삽입해두었기에 디버깅 중 실시간으로 순환 참조 문제를 발견할 수 있었습니다. PhotoKit 관련 동시성 작업 진행 후 Record, Exclude 화면에서 각 객체가 해제되지 않는 것을 발견했고, 이는 작은 부분에서 발생함을 확인했습니다.
~~~swift
actionSheetAction
    .bind(with: self) { owner, action in // ⭐️⭐️⭐️ 1. 맨 처음 with을 통해 약한 참조로 self를 전달합니다.
        switch action {
        case .exclude:
            let assetIdentifiers = owner.selectedAssetIdentifiers()
            UserDefaultsService.excludeAssets.append(contentsOf: assetIdentifiers)
            owner.output.viewDidRefresh.accept(())
            owner.output.selectedRecordCells.accept([])
            
        case .remove:
            owner.output.toggleLoading.accept(true)
            let assetIdentifiers = owner.selectedAssetIdentifiers()
            owner.photoKitService.deletePhotos(from: assetIdentifiers)
                .bind(with: self) { owner, isSuccess in // ⭐️⭐️⭐️ 2. 아래에서 다시 한번 약한 참조로 self를 전달합니다.
                    if isSuccess {
                        owner.output.selectedRecordCells.accept([])
                    } else {
                        owner.output.alertPresented.accept(owner.removeFailedAlert)
                    }
                    owner.output.toggleLoading.accept(false)
                }
                .disposed(by: owner.disposeBag)
        }
    }
    .disposed(by: disposeBag)
~~~

이는 같은 바인딩 구문 내에서 같은 객체를 두번 참조하게 되어 발생한 문제였습니다. 이를 해결하기 위해 가장 상단에서는 기존과 같이 bind(with: self)를 통해 약한 참조로 전달하고, 아래에선 위에서 캡처 후 반환된 `owner`를 사용함으로써 순환 참조를 해결할 수 있었습니다.

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|TitleView TextField SubLabel 추가|<img width="300" alt="" src="https://github.com/user-attachments/assets/e19b22dc-c9d3-48bc-9acc-afbc78f8a0de">|
|1.3.0 심사 완료|<img width="600" alt="" src="https://github.com/user-attachments/assets/0a29f222-e36f-4c20-90f7-178abf8ae384">|