### PR TITLE
유닛 테스트 환경 세팅 및 작성

### DIFF
--- a/poporazzi.xcodeproj/project.pbxproj
+++ b/poporazzi.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Data/Service/LiveActivityService.swift,
+				Domain/Entity/Album.swift,
+				Domain/Interface/LiveActivityInterface.swift,
 				Resource/Colors.xcassets,
 				Resource/Font/DovemayoGothic/Dovemayo_gothic.ttf,
 				Resource/Images.xcassets,

--- a/poporazzi.xcodeproj/project.pbxproj
+++ b/poporazzi.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				poporazzi.xctestplan,
 			);
 			target = 8232593B2D9FBF4800CFC860 /* poporazzi */;
 		};

--- a/poporazzi.xcodeproj/project.pbxproj
+++ b/poporazzi.xcodeproj/project.pbxproj
@@ -24,6 +24,13 @@
 			remoteGlobalIDString = 8221E3462DC3668F0092469D;
 			remoteInfo = poporazziWidgetExtension;
 		};
+		82D69E9F2DCB2990008C6AE5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 823259342D9FBF4800CFC860 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8232593B2D9FBF4800CFC860;
+			remoteInfo = poporazzi;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -45,6 +52,7 @@
 		8221E3492DC3668F0092469D /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		8221E34B2DC3668F0092469D /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		8232593C2D9FBF4800CFC860 /* poporazzi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = poporazzi.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		82D69E9B2DCB2990008C6AE5 /* poporazziTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = poporazziTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -103,6 +111,11 @@
 			path = poporazzi;
 			sourceTree = "<group>";
 		};
+		82D69E9C2DCB2990008C6AE5 /* poporazziTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = poporazziTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +139,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		82D69E982DCB2990008C6AE5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -143,6 +163,7 @@
 			children = (
 				8232593E2D9FBF4800CFC860 /* poporazzi */,
 				8221E34D2DC3668F0092469D /* poporazziWidget */,
+				82D69E9C2DCB2990008C6AE5 /* poporazziTests */,
 				8221E3482DC3668F0092469D /* Frameworks */,
 				8232593D2D9FBF4800CFC860 /* Products */,
 			);
@@ -153,6 +174,7 @@
 			children = (
 				8232593C2D9FBF4800CFC860 /* poporazzi.app */,
 				8221E3472DC3668F0092469D /* poporazziWidgetExtension.appex */,
+				82D69E9B2DCB2990008C6AE5 /* poporazziTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -210,6 +232,29 @@
 			productReference = 8232593C2D9FBF4800CFC860 /* poporazzi.app */;
 			productType = "com.apple.product-type.application";
 		};
+		82D69E9A2DCB2990008C6AE5 /* poporazziTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 82D69EA12DCB2990008C6AE5 /* Build configuration list for PBXNativeTarget "poporazziTests" */;
+			buildPhases = (
+				82D69E972DCB2990008C6AE5 /* Sources */,
+				82D69E982DCB2990008C6AE5 /* Frameworks */,
+				82D69E992DCB2990008C6AE5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				82D69EA02DCB2990008C6AE5 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				82D69E9C2DCB2990008C6AE5 /* poporazziTests */,
+			);
+			name = poporazziTests;
+			packageProductDependencies = (
+			);
+			productName = poporazziTests;
+			productReference = 82D69E9B2DCB2990008C6AE5 /* poporazziTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -225,6 +270,10 @@
 					};
 					8232593B2D9FBF4800CFC860 = {
 						CreatedOnToolsVersion = 16.2;
+					};
+					82D69E9A2DCB2990008C6AE5 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 8232593B2D9FBF4800CFC860;
 					};
 				};
 			};
@@ -249,6 +298,7 @@
 			targets = (
 				8232593B2D9FBF4800CFC860 /* poporazzi */,
 				8221E3462DC3668F0092469D /* poporazziWidgetExtension */,
+				82D69E9A2DCB2990008C6AE5 /* poporazziTests */,
 			);
 		};
 /* End PBXProject section */
@@ -262,6 +312,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		8232593A2D9FBF4800CFC860 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		82D69E992DCB2990008C6AE5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -285,6 +342,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		82D69E972DCB2990008C6AE5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -292,6 +356,11 @@
 			isa = PBXTargetDependency;
 			target = 8221E3462DC3668F0092469D /* poporazziWidgetExtension */;
 			targetProxy = 8221E35B2DC366900092469D /* PBXContainerItemProxy */;
+		};
+		82D69EA02DCB2990008C6AE5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8232593B2D9FBF4800CFC860 /* poporazzi */;
+			targetProxy = 82D69E9F2DCB2990008C6AE5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -380,7 +449,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -416,7 +485,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -543,6 +612,42 @@
 			};
 			name = Release;
 		};
+		82D69EA22DCB2990008C6AE5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9XG4S4XZWN;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.thinkyside.poporazziTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/poporazzi.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/poporazzi";
+			};
+			name = Debug;
+		};
+		82D69EA32DCB2990008C6AE5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9XG4S4XZWN;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.thinkyside.poporazziTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/poporazzi.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/poporazzi";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -569,6 +674,15 @@
 			buildConfigurations = (
 				823259502D9FBF4900CFC860 /* Debug */,
 				823259512D9FBF4900CFC860 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		82D69EA12DCB2990008C6AE5 /* Build configuration list for PBXNativeTarget "poporazziTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				82D69EA22DCB2990008C6AE5 /* Debug */,
+				82D69EA32DCB2990008C6AE5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazzi.xcscheme
+++ b/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazzi.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82D69E9A2DCB2990008C6AE5"
+               BuildableName = "poporazziTests.xctest"
+               BlueprintName = "poporazziTests"
+               ReferencedContainer = "container:poporazzi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazzi.xcscheme
+++ b/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazzi.xcscheme
@@ -27,8 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:poporazzi.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazziWidgetExtension.xcscheme
+++ b/poporazzi.xcodeproj/xcshareddata/xcschemes/poporazziWidgetExtension.xcscheme
@@ -44,6 +44,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "82D69E9A2DCB2990008C6AE5"
+               BuildableName = "poporazziTests.xctest"
+               BlueprintName = "poporazziTests"
+               ReferencedContainer = "container:poporazzi.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -20,6 +20,8 @@ final class Coordinator {
     
     /// 진입 화면을 설정합니다.
     func start() {
+        DIContainer.shared.inject(.liveValue)
+        
         let titleInputVM = TitleInputViewModel(output: .init())
         let titleInputVC = TitleInputViewController(viewModel: titleInputVM)
         navigationController = UINavigationController(rootViewController: titleInputVC)

--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -20,7 +20,6 @@ final class DIContainer {
     final class Dependencies {
         let liveActivityService = LiveActivityService()
         let photoKitService = PhotoKitService()
-        let versionService = VersionService()
     }
     
     /// 객체를 꺼내옵니다.

--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -14,17 +14,47 @@ final class DIContainer {
     private init() {}
     
     /// 의존성이 담긴 객체
-    private let dependencies = Dependencies()
+    private var dependencies: Dependencies!
     
     /// 의존성 리스트
-    final class Dependencies {
-        let liveActivityService = LiveActivityService()
-        let photoKitService = PhotoKitService()
+    struct Dependencies {
+        let liveActivityService: LiveActivityInterface
+        let photoKitService: PhotoKitService
     }
     
     /// 객체를 꺼내옵니다.
     fileprivate func resolve<T>(_ keyPath: KeyPath<Dependencies, T>) -> T {
         dependencies[keyPath: keyPath]
+    }
+}
+
+// MARK: - Inject
+
+extension DIContainer {
+    
+    /// 주입 할 객체를 반환합니다.
+    enum InjectObject {
+        case liveValue
+        case testValue
+        
+        /// 의존성 객체
+        var dependencies: Dependencies {
+            switch self {
+            case .liveValue: .init(
+                liveActivityService: LiveActivityService(),
+                photoKitService: PhotoKitService()
+            )
+            case .testValue: .init(
+                liveActivityService: MockLiveActivityService(),
+                photoKitService: PhotoKitService()
+            )
+            }
+        }
+    }
+    
+    /// 의존성을 주입합니다.
+    func inject(_ injectObject: InjectObject) {
+        dependencies = injectObject.dependencies
     }
 }
 

--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -19,7 +19,7 @@ final class DIContainer {
     /// 의존성 리스트
     struct Dependencies {
         let liveActivityService: LiveActivityInterface
-        let photoKitService: PhotoKitService
+        let photoKitService: PhotoKitInterface
     }
     
     /// 객체를 꺼내옵니다.
@@ -46,7 +46,7 @@ extension DIContainer {
             )
             case .testValue: .init(
                 liveActivityService: MockLiveActivityService(),
-                photoKitService: PhotoKitService()
+                photoKitService: MockPhotoKitService()
             )
             }
         }

--- a/poporazzi/Data/Manager/DeepLinkManager.swift
+++ b/poporazzi/Data/Manager/DeepLinkManager.swift
@@ -1,5 +1,5 @@
 //
-//  DeepLinkService.swift
+//  DeepLinkManager.swift
 //  poporazzi
 //
 //  Created by 김민준 on 5/7/25.
@@ -7,7 +7,8 @@
 
 import UIKit
 
-struct DeepLinkService {
+/// DeepLink 관리용
+enum DeepLinkManager {
     
     /// 사진 앱의 앨범으로 딥링크합니다.
     static func openPhotoAlbum() {

--- a/poporazzi/Data/Manager/HapticManager.swift
+++ b/poporazzi/Data/Manager/HapticManager.swift
@@ -1,5 +1,5 @@
 //
-//  HapticService.swift
+//  HapticManager.swift
 //  poporazzi
 //
 //  Created by 김민준 on 5/7/25.
@@ -7,14 +7,17 @@
 
 import UIKit
 
-enum HapticService {
+/// 햅틱 관리용
+enum HapticManager {
     
     private static let notificationGenerator = UINotificationFeedbackGenerator()
     
+    /// 알림 유형의 햅틱을 실행합니다.
     static func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
         notificationGenerator.notificationOccurred(type)
     }
     
+    /// 세기 별 햅틱을 실행합니다.
     static func impact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
         UIImpactFeedbackGenerator(style: style).impactOccurred()
     }

--- a/poporazzi/Data/Manager/VersionManager.swift
+++ b/poporazzi/Data/Manager/VersionManager.swift
@@ -1,5 +1,5 @@
 //
-//  VersionService.swift
+//  VersionManager.swift
 //  poporazzi
 //
 //  Created by 김민준 on 5/3/25.
@@ -8,7 +8,8 @@
 import UIKit
 import RxSwift
 
-struct VersionService {
+/// 버전 관리용
+enum VersionManager {
     
     /// 각 URLString을 저장하는 열거형
     enum URLString {
@@ -35,15 +36,15 @@ struct VersionService {
 
 // MARK: - Use Case
 
-extension VersionService {
+extension VersionManager {
     
     /// 현재 디바이스에 설치된 버전을 반환합니다.
-    var deviceAppVersion: String {
+    static var deviceAppVersion: String {
         return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
     }
     
     /// 앱스토어 내 최신 버전을 반환합니다.
-    var appStoreAppVersion: Observable<String> {
+    static var appStoreAppVersion: Observable<String> {
         guard let url = URL(string: URLString.version.value) else { return .never() }
         
         return Observable.create { observer in
@@ -65,7 +66,7 @@ extension VersionService {
     }
     
     /// 앱스토어를 Open합니다.
-    func openAppStore() {
+    static func openAppStore() {
         guard let url = URL(string: URLString.appStore.value) else { return }
         if UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/poporazzi/Data/Mock/MockLiveActivityService.swift
+++ b/poporazzi/Data/Mock/MockLiveActivityService.swift
@@ -1,0 +1,22 @@
+//
+//  MockLiveActivityService.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import Foundation
+
+struct MockLiveActivityService: LiveActivityInterface {
+    func start(to album: Album) {
+        print("[Live Activity 시작] - \(album.title), \(album.trackingStartDate.startDateFullFormat)")
+    }
+    
+    func update(to album: Album, totalCount: Int) {
+        print("[Live Activity 업데이트] - \(album.title), \(album.trackingStartDate.startDateFullFormat), 총\(totalCount)개")
+    }
+    
+    func stop() {
+        print("[Live Activity 종료]")
+    }
+}

--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -20,33 +20,15 @@ struct MockPhotoKitService: PhotoKitInterface {
     }
     
     func fetchMediasWithNoThumbnail(mediaFetchType: MediaFetchType, date: Date, ascending: Bool) -> [Media] {
-        [
-            Media(id: "0", mediaType: .photo),
-            Media(id: "1", mediaType: .photo),
-            Media(id: "2", mediaType: .video(duration: 1000)),
-            Media(id: "3", mediaType: .photo),
-            Media(id: "4", mediaType: .photo),
-            Media(id: "5", mediaType: .video(duration: 2000)),
-            Media(id: "6", mediaType: .photo),
-            Media(id: "7", mediaType: .photo),
-            Media(id: "8", mediaType: .video(duration: 3000)),
-            Media(id: "9", mediaType: .photo)
-        ]
+        Array(repeatElement(Media(id: UUID().uuidString, mediaType: .photo), count: 30))
     }
     
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]> {
-        .just([
-            OrderedMedia(0, .init(id: "0", mediaType: .photo, thumbnail: UIImage())),
-            OrderedMedia(1, .init(id: "1", mediaType: .photo, thumbnail: UIImage())),
-            OrderedMedia(2, .init(id: "2", mediaType: .video(duration: 1000))),
-            OrderedMedia(3, .init(id: "3", mediaType: .photo, thumbnail: UIImage())),
-            OrderedMedia(4, .init(id: "4", mediaType: .photo, thumbnail: UIImage())),
-            OrderedMedia(5, .init(id: "5", mediaType: .video(duration: 2000), thumbnail: UIImage())),
-            OrderedMedia(6, .init(id: "6", mediaType: .photo, thumbnail: UIImage())),
-            OrderedMedia(7, .init(id: "7", mediaType: .photo, thumbnail: UIImage())),
-            OrderedMedia(8, .init(id: "8", mediaType: .video(duration: 3000), thumbnail: UIImage())),
-            OrderedMedia(9, .init(id: "9", mediaType: .photo, thumbnail: UIImage())),
-        ])
+        var array = [OrderedMedia]()
+        for i in 0..<30 {
+            array.append((i, Media(id: UUID().uuidString, mediaType: .photo, thumbnail: UIImage())))
+        }
+        return .just(array)
     }
     
     func saveAlbum(title: String) throws {

--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -1,0 +1,59 @@
+//
+//  MockPhotoKitService.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+struct MockPhotoKitService: PhotoKitInterface {
+    
+    var photoLibraryChange: Signal<Void> {
+        PublishRelay<Void>().asSignal()
+    }
+    
+    func requestAuth() {
+        print("[권한 허용 완료]")
+    }
+    
+    func fetchMediasWithNoThumbnail(mediaFetchType: MediaFetchType, date: Date, ascending: Bool) -> [Media] {
+        [
+            Media(id: "0", mediaType: .photo),
+            Media(id: "1", mediaType: .photo),
+            Media(id: "2", mediaType: .video(duration: 1000)),
+            Media(id: "3", mediaType: .photo),
+            Media(id: "4", mediaType: .photo),
+            Media(id: "5", mediaType: .video(duration: 2000)),
+            Media(id: "6", mediaType: .photo),
+            Media(id: "7", mediaType: .photo),
+            Media(id: "8", mediaType: .video(duration: 3000)),
+            Media(id: "9", mediaType: .photo)
+        ]
+    }
+    
+    func fetchMedias(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]> {
+        .just([
+            OrderedMedia(0, .init(id: "0", mediaType: .photo, thumbnail: UIImage())),
+            OrderedMedia(1, .init(id: "1", mediaType: .photo, thumbnail: UIImage())),
+            OrderedMedia(2, .init(id: "2", mediaType: .video(duration: 1000))),
+            OrderedMedia(3, .init(id: "3", mediaType: .photo, thumbnail: UIImage())),
+            OrderedMedia(4, .init(id: "4", mediaType: .photo, thumbnail: UIImage())),
+            OrderedMedia(5, .init(id: "5", mediaType: .video(duration: 2000), thumbnail: UIImage())),
+            OrderedMedia(6, .init(id: "6", mediaType: .photo, thumbnail: UIImage())),
+            OrderedMedia(7, .init(id: "7", mediaType: .photo, thumbnail: UIImage())),
+            OrderedMedia(8, .init(id: "8", mediaType: .video(duration: 3000), thumbnail: UIImage())),
+            OrderedMedia(9, .init(id: "9", mediaType: .photo, thumbnail: UIImage())),
+        ])
+    }
+    
+    func saveAlbum(title: String) throws {
+        print("[앨범 저장 완료] - \(title)")
+    }
+    
+    func deletePhotos(from assetIdentifiers: [String]) -> Observable<Bool> {
+        .just(true)
+    }
+}

--- a/poporazzi/Data/Service/LiveActivityService.swift
+++ b/poporazzi/Data/Service/LiveActivityService.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ActivityKit
 
-final class LiveActivityService {
+final class LiveActivityService: LiveActivityInterface {
     
     private var activity: Activity<PoporazziWidgetAttributes>?
 }
@@ -18,12 +18,12 @@ final class LiveActivityService {
 extension LiveActivityService {
     
     /// Live Activity를 시작합니다.
-    func start(albumTitle: String, startDate: Date) {
+    func start(to album: Album) {
         guard activity == nil else { return }
         let attributes = PoporazziWidgetAttributes()
         let contentState = PoporazziWidgetAttributes.ContentState(
-            albumTitle: albumTitle,
-            startDate: startDate,
+            albumTitle: album.title,
+            startDate: album.trackingStartDate,
             totalCount: 0
         )
         let content = ActivityContent(state: contentState, staleDate: nil)
@@ -40,12 +40,12 @@ extension LiveActivityService {
     }
     
     /// Live Activity를 업데이트합니다.
-    func update(albumTitle: String, startDate: Date, totalCount: Int) {
+    func update(to album: Album, totalCount: Int) {
         guard let activity = activity else { return }
         
         let contentState = PoporazziWidgetAttributes.ContentState(
-            albumTitle: albumTitle,
-            startDate: startDate,
+            albumTitle: album.title,
+            startDate: album.trackingStartDate,
             totalCount: totalCount
         )
         let content = ActivityContent(state: contentState, staleDate: nil)

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -10,14 +10,7 @@ import RxSwift
 import RxCocoa
 import Photos
 
-final class PhotoKitService: NSObject {
-    
-    /// 미디어 검색 타입
-    enum MediaFetchType {
-        case all
-        case image
-        case video
-    }
+final class PhotoKitService: NSObject, PhotoKitInterface {
     
     /// PhotoKit에서 발생할 수 있는 에러
     enum PhotoKitError: Error {
@@ -62,7 +55,7 @@ extension PhotoKitService {
     }
     
     /// 썸네일 없이 기록을 반환합니다.
-    func fetchPhotosWithNoThumbnail(
+    func fetchMediasWithNoThumbnail(
         mediaFetchType: MediaFetchType = .all,
         date: Date,
         ascending: Bool = true
@@ -88,7 +81,7 @@ extension PhotoKitService {
     }
     
     /// Asset Identifier를 기준으로 Media 배열을 반환합니다.
-    func fetchPhotos(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]> {
+    func fetchMedias(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]> {
         return Observable.create { [weak self] observer in
             Task.detached { [weak self] in
                 guard let self else {

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -24,8 +24,18 @@ struct Media: Hashable, Equatable {
     }
 }
 
+/// 순서 보장이 필요한 Media 튜플
+typealias OrderedMedia = (Int, Media)
+
 /// 미디어 타입
 enum MediaType: Hashable {
     case photo
     case video(duration: TimeInterval)
+}
+
+/// 미디어 검색 타입
+enum MediaFetchType {
+    case all
+    case image
+    case video
 }

--- a/poporazzi/Domain/Interface/LiveActivityInterface.swift
+++ b/poporazzi/Domain/Interface/LiveActivityInterface.swift
@@ -1,0 +1,20 @@
+//
+//  LiveActivityInterface.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import Foundation
+
+protocol LiveActivityInterface {
+    
+    /// Live Activity를 시작합니다.
+    func start(to album: Album)
+    
+    /// Live Activity를 업데이트합니다.
+    func update(to album: Album, totalCount: Int)
+    
+    /// Live Activity를 종료합니다.
+    func stop()
+}

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -1,0 +1,35 @@
+//
+//  PhotoKitInterface.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+protocol PhotoKitInterface {
+    
+    /// PhotoLibrary에 변화가 감지될 때 전송되는 이벤트
+    var photoLibraryChange: Signal<Void> { get }
+    
+    /// PhotoLibrary 사용 권한을 요청합니다.
+    func requestAuth()
+    
+    /// Thumbnail 없이 Media 배열을 반환합니다.
+    func fetchMediasWithNoThumbnail(
+        mediaFetchType: MediaFetchType,
+        date: Date,
+        ascending: Bool
+    ) -> [Media]
+    
+    /// Media 배열 이벤트를 반환합니다.
+    func fetchMedias(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]>
+    
+    /// 현재 fetchResult를 기준으로 앨범을 저장합니다.
+    func saveAlbum(title: String) throws
+    
+    /// 사진을 삭제 후 결과 이벤트를 반환합니다.
+    func deletePhotos(from assetIdentifiers: [String]) -> Observable<Bool>
+}

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
@@ -11,7 +11,6 @@ import RxCocoa
 
 final class TitleInputViewModel: ViewModel {
     
-    @Dependency(\.versionService) private var versionService
     @Dependency(\.liveActivityService) private var liveActivityService
     
     private let disposeBag = DisposeBag()
@@ -75,7 +74,7 @@ extension TitleInputViewModel {
                     albumTitle: album.title,
                     startDate: album.trackingStartDate
                 )
-                HapticService.notification(type: .success)
+                HapticManager.notification(type: .success)
                 UserDefaultsService.album = album
                 UserDefaultsService.isTracking = true
             }
@@ -85,16 +84,16 @@ extension TitleInputViewModel {
             .bind(with: self) { owner, action in
                 switch action {
                 case .openAppStore:
-                    owner.versionService.openAppStore()
+                    VersionManager.openAppStore()
                 }
             }
             .disposed(by: disposeBag)
         
 #if !DEBUG
-        versionService.appStoreAppVersion
+        VersionService.appStoreAppVersion
             .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
             .bind(with: self) { owner, appStoreVersion in
-                if appStoreVersion != owner.versionService.deviceAppVersion {
+                if appStoreVersion != VersionService.deviceAppVersion {
                     owner.output.alertPresented.accept(owner.recommendUpdateAlert)
                 }
             }

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
@@ -11,7 +11,7 @@ import RxCocoa
 
 final class TitleInputViewModel: ViewModel {
     
-    @Dependency(\.liveActivityService) private var liveActivityService
+    @Dependency(\.liveActivityService) var liveActivityService
     
     private let disposeBag = DisposeBag()
     private let output: Output
@@ -70,10 +70,7 @@ extension TitleInputViewModel {
             .emit(with: self) { owner, _ in
                 let album = Album(title: owner.output.titleText.value, trackingStartDate: .now)
                 owner.navigation.accept(.pushRecord(album))
-                owner.liveActivityService.start(
-                    albumTitle: album.title,
-                    startDate: album.trackingStartDate
-                )
+                owner.liveActivityService.start(to: album)
                 HapticManager.notification(type: .success)
                 UserDefaultsService.album = album
                 UserDefaultsService.isTracking = true

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -10,8 +10,6 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-typealias OrderedMedia = (Int, Media)
-
 final class RecordViewModel: ViewModel {
     
     @Dependency(\.liveActivityService) private var liveActivityService
@@ -345,15 +343,19 @@ extension RecordViewModel {
     /// - 제외된 사진을 필터링합니다.
     private func fetchAllMediaListWithNoThumbnail() -> [Media] {
         let trackingStartDate = output.album.value.trackingStartDate
-        return photoKitService.fetchPhotosWithNoThumbnail(date: trackingStartDate)
-            .filter { media in
-                !Set(UserDefaultsService.excludeAssets).contains(media.id)
-            }
+        return photoKitService.fetchMediasWithNoThumbnail(
+            mediaFetchType: .all,
+            date: trackingStartDate,
+            ascending: true
+        )
+        .filter { media in
+            !Set(UserDefaultsService.excludeAssets).contains(media.id)
+        }
     }
     
     /// Asset Identifiers에 대응되는 Media 스트림을 반환합니다.
     private func requestImages(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]> {
-        photoKitService.fetchPhotos(from: assetIdentifiers)
+        photoKitService.fetchMedias(from: assetIdentifiers)
     }
     
     /// 앨범에 저장합니다.

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -245,7 +245,6 @@ extension RecordViewModel {
                 case .save:
                     if owner.output.mediaList.value.isEmpty {
                         owner.navigation.accept(.pop)
-                        UserDefaultsService.excludeAssets.removeAll()
                     } else {
                         try? owner.saveToAlbums()
                         owner.output.alertPresented.accept(owner.saveCompleteAlert)
@@ -253,17 +252,16 @@ extension RecordViewModel {
                     }
                     
                     owner.liveActivityService.stop()
+                    UserDefaultsService.excludeAssets.removeAll()
                     UserDefaultsService.isTracking = false
                     
                 case .linkToPhotoAlbum:
                     DeepLinkManager.openPhotoAlbum()
                     owner.navigation.accept(.pop)
-                    UserDefaultsService.excludeAssets.removeAll()
                     break
                     
                 case .popToHome:
                     owner.navigation.accept(.pop)
-                    UserDefaultsService.excludeAssets.removeAll()
                 }
             }
             .disposed(by: disposeBag)

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -189,8 +189,7 @@ extension RecordViewModel {
         output.mediaList
             .bind(with: self) { owner, mediaList in
                 owner.liveActivityService.update(
-                    albumTitle: owner.output.album.value.title,
-                    startDate: owner.output.album.value.trackingStartDate,
+                    to: owner.output.album.value,
                     totalCount: mediaList.count
                 )
             }
@@ -330,7 +329,7 @@ extension RecordViewModel {
 // MARK: - Helper
 
 extension RecordViewModel {
-
+    
     /// IndexPath에 대응되는 Asset Identifiers를 반환합니다.
     private func selectedAssetIdentifiers() -> [String] {
         output.selectedRecordCells.value.compactMap { output.mediaList.value[$0.row].id }

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -252,14 +252,14 @@ extension RecordViewModel {
                     } else {
                         try? owner.saveToAlbums()
                         owner.output.alertPresented.accept(owner.saveCompleteAlert)
-                        HapticService.notification(type: .success)
+                        HapticManager.notification(type: .success)
                     }
                     
                     owner.liveActivityService.stop()
                     UserDefaultsService.isTracking = false
                     
                 case .linkToPhotoAlbum:
-                    DeepLinkService.openPhotoAlbum()
+                    DeepLinkManager.openPhotoAlbum()
                     owner.navigation.accept(.pop)
                     UserDefaultsService.excludeAssets.removeAll()
                     break

--- a/poporazzi/Feature/5.ExcludeRecord/ExcludeRecordViewModel.swift
+++ b/poporazzi/Feature/5.ExcludeRecord/ExcludeRecordViewModel.swift
@@ -174,7 +174,7 @@ extension ExcludeRecordViewModel {
     /// 제외된 사진을 반환합니다.
     private func fetchExcludePhotos() -> Observable<[Media]> {
         let assetIdentifiers = UserDefaultsService.excludeAssets
-        return photoKitService.fetchPhotos(from: assetIdentifiers).map { $0.map { $0.1 } }
+        return photoKitService.fetchMedias(from: assetIdentifiers).map { $0.map { $0.1 } }
     }
 }
 

--- a/poporazzi/poporazzi.xctestplan
+++ b/poporazzi/poporazzi.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "B06C9849-A4D7-45B5-A797-4A94D5C5CDC4",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:poporazzi.xcodeproj",
+      "identifier" : "8232593B2D9FBF4800CFC860",
+      "name" : "poporazzi"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:poporazzi.xcodeproj",
+        "identifier" : "82D69E9A2DCB2990008C6AE5",
+        "name" : "poporazziTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/poporazziTests/Feature/1.TitleInput/TitleInputTests.swift
+++ b/poporazziTests/Feature/1.TitleInput/TitleInputTests.swift
@@ -14,14 +14,12 @@ final class TitleInputTests: XCTestCase {
     
     private var viewModel: TitleInputViewModel!
     
-    /// 각각의 Test Method를 실행하기 전에 모든 상태를 reset해주는 함수
     override func setUpWithError() throws {
         DIContainer.shared.inject(.testValue)
         viewModel = TitleInputViewModel(output: .init())
         try super.setUpWithError()
     }
     
-    /// 각각의 Test Method들이 끝나고 난 뒤에 cleanup을 수행해주는 함수
     override func tearDownWithError() throws {
         viewModel = nil
         try super.tearDownWithError()
@@ -37,31 +35,33 @@ final class TitleInputTests: XCTestCase {
 
 extension TitleInputTests {
     
-    /// 테스트 메소드의 이름은 항상 'test'로 시작하고
-    /// 뒤에는 무엇을 테스트하는지 설명해줘야한다.
     func test_앨범제목입력() throws {
-        
-        // 1. given: 필요한 모든 값 설정
         let (input, output) = makeInputOutput()
         
-        // 2. when: 테스트 중인 코드 실행
         let testTitle = "콜드플레이 내한 콘서트"
         input.titleTextChanged.accept(testTitle)
         
-        // 3. then: 에상 결과 확인
         XCTAssertEqual(output.titleText.value, testTitle)
         XCTAssertTrue(output.isStartButtonEnabled.value)
     }
     
-    func test_라이브액티비티시작() throws {
-        
-        // 1. given: 필요한 모든 값 설정
+    func test_시작버튼활성화() throws {
         let (input, output) = makeInputOutput()
         
-        // 2. when: 테스트 중인 코드 실행
-        let testTitle = "콜드플레이 내한 콘서트"
+        XCTAssertTrue(!output.isStartButtonEnabled.value)
+        input.titleTextChanged.accept("테스트")
+        XCTAssertTrue(output.isStartButtonEnabled.value)
+        input.titleTextChanged.accept("")
+        XCTAssertTrue(!output.isStartButtonEnabled.value)
+    }
+    
+    func test_시작후저장값() throws {
+        let (input, output) = makeInputOutput()
+        let testTitle = "테스트"
         input.titleTextChanged.accept(testTitle)
         input.startButtonTapped.accept(())
+        XCTAssertTrue(UserDefaultsService.albumTitle == testTitle)
+        XCTAssertTrue(UserDefaultsService.isTracking)
     }
 }
 

--- a/poporazziTests/Feature/1.TitleInput/TitleInputTests.swift
+++ b/poporazziTests/Feature/1.TitleInput/TitleInputTests.swift
@@ -16,6 +16,7 @@ final class TitleInputTests: XCTestCase {
     
     /// 각각의 Test Method를 실행하기 전에 모든 상태를 reset해주는 함수
     override func setUpWithError() throws {
+        DIContainer.shared.inject(.testValue)
         viewModel = TitleInputViewModel(output: .init())
         try super.setUpWithError()
     }
@@ -44,11 +45,23 @@ extension TitleInputTests {
         let (input, output) = makeInputOutput()
         
         // 2. when: 테스트 중인 코드 실행
-        input.titleTextChanged.accept("콜드플레이 내한 콘서트")
+        let testTitle = "콜드플레이 내한 콘서트"
+        input.titleTextChanged.accept(testTitle)
         
         // 3. then: 에상 결과 확인
-        XCTAssertEqual(output.titleText.value, "콜드플레이 내한 콘서트")
+        XCTAssertEqual(output.titleText.value, testTitle)
         XCTAssertTrue(output.isStartButtonEnabled.value)
+    }
+    
+    func test_라이브액티비티시작() throws {
+        
+        // 1. given: 필요한 모든 값 설정
+        let (input, output) = makeInputOutput()
+        
+        // 2. when: 테스트 중인 코드 실행
+        let testTitle = "콜드플레이 내한 콘서트"
+        input.titleTextChanged.accept(testTitle)
+        input.startButtonTapped.accept(())
     }
 }
 

--- a/poporazziTests/Feature/1.TitleInput/TitleInputTests.swift
+++ b/poporazziTests/Feature/1.TitleInput/TitleInputTests.swift
@@ -26,24 +26,46 @@ final class TitleInputTests: XCTestCase {
         try super.tearDownWithError()
     }
     
+    typealias TestInput = (
+        titleTextChanged: PublishRelay<String>,
+        startButtonTapped: PublishRelay<Void>
+    )
+}
+
+// MARK: - Tests
+
+extension TitleInputTests {
+    
     /// 테스트 메소드의 이름은 항상 'test'로 시작하고
     /// 뒤에는 무엇을 테스트하는지 설명해줘야한다.
     func test_앨범제목입력() throws {
         
         // 1. given: 필요한 모든 값 설정
-        let titleTextChanged = PublishRelay<String>()
-        let startButtonTapped = PublishRelay<Void>()
-        let input = TitleInputViewModel.Input(
-            titleTextChanged: titleTextChanged.asSignal(),
-            startButtonTapped: startButtonTapped.asSignal()
-        )
-        let output = viewModel.transform(input)
+        let (input, output) = makeInputOutput()
         
         // 2. when: 테스트 중인 코드 실행
-        titleTextChanged.accept("콜드플레이 내한 콘서트")
+        input.titleTextChanged.accept("콜드플레이 내한 콘서트")
         
         // 3. then: 에상 결과 확인
         XCTAssertEqual(output.titleText.value, "콜드플레이 내한 콘서트")
         XCTAssertTrue(output.isStartButtonEnabled.value)
+    }
+}
+
+// MARK: - Input & Output
+
+extension TitleInputTests {
+    
+    func makeInputOutput() -> (TestInput, TitleInputViewModel.Output) {
+        let testInput = (
+            titleTextChanged: PublishRelay<String>(),
+            startButtonTapped: PublishRelay<Void>()
+        )
+        let input = TitleInputViewModel.Input(
+            titleTextChanged: testInput.titleTextChanged.asSignal(),
+            startButtonTapped: testInput.startButtonTapped.asSignal()
+        )
+        let output = viewModel.transform(input)
+        return (testInput, output)
     }
 }

--- a/poporazziTests/Feature/2.Record/RecordTests.swift
+++ b/poporazziTests/Feature/2.Record/RecordTests.swift
@@ -1,0 +1,87 @@
+//
+//  RecordTests.swift
+//  poporazziTests
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import XCTest
+import RxSwift
+import RxCocoa
+@testable import poporazzi
+
+final class RecordTests: XCTestCase {
+    
+    private var viewModel: RecordViewModel!
+    
+    override func setUpWithError() throws {
+        viewModel = RecordViewModel(output: .init(album: .init(value: .initialValue)))
+        try super.setUpWithError()
+    }
+    
+    override func tearDownWithError() throws {
+        viewModel = nil
+        try super.tearDownWithError()
+    }
+    
+    typealias TestInput = (
+        selectButtonTapped: PublishRelay<Void>,
+        selectCancelButtonTapped: PublishRelay<Void>,
+        recentIndexPath: BehaviorRelay<IndexPath>,
+        recordCellSelected: PublishRelay<IndexPath>,
+        recordCellDeselected: PublishRelay<IndexPath>,
+        excludeButtonTapped: PublishRelay<Void>,
+        removeButtonTapped: PublishRelay<Void>,
+        finishButtonTapped: PublishRelay<Void>
+    )
+}
+
+// MARK: - Tests
+
+extension RecordTests {
+    
+    func test_앨범제목입력() throws {
+        
+        // 1. given: 필요한 모든 값 설정
+        let (input, output) = makeInputOutput()
+        
+        // 2. when: 테스트 중인 코드 실행
+        
+        
+        // 3. then: 에상 결과 확인
+        
+    }
+}
+
+// MARK: - Input & Output
+
+extension RecordTests {
+    
+    func makeInputOutput() -> (TestInput, RecordViewModel.Output) {
+        let testInput = TestInput(
+            selectButtonTapped: PublishRelay<Void>(),
+            selectCancelButtonTapped: PublishRelay<Void>(),
+            recentIndexPath: BehaviorRelay<IndexPath>(value: .init(row: 0, section: 0)),
+            recordCellSelected: PublishRelay<IndexPath>(),
+            recordCellDeselected: PublishRelay<IndexPath>(),
+            excludeButtonTapped: PublishRelay<Void>(),
+            removeButtonTapped: PublishRelay<Void>(),
+            finishButtonTapped: PublishRelay<Void>()
+        )
+        
+        let input = RecordViewModel.Input(
+            viewDidLoad: .just(()),
+            selectButtonTapped: testInput.selectButtonTapped.asSignal(),
+            selectCancelButtonTapped: testInput.selectCancelButtonTapped.asSignal(),
+            recentIndexPath: testInput.recentIndexPath,
+            recordCellSelected: testInput.recordCellSelected.asSignal(),
+            recordCellDeselected: testInput.recordCellDeselected.asSignal(),
+            excludeButtonTapped: testInput.excludeButtonTapped.asSignal(),
+            removeButtonTapped: testInput.removeButtonTapped.asSignal(),
+            finishButtonTapped: testInput.finishButtonTapped.asSignal()
+        )
+        let output = viewModel.transform(input)
+        
+        return (testInput, output)
+    }
+}

--- a/poporazziTests/Feature/2.Record/RecordTests.swift
+++ b/poporazziTests/Feature/2.Record/RecordTests.swift
@@ -15,6 +15,7 @@ final class RecordTests: XCTestCase {
     private var viewModel: RecordViewModel!
     
     override func setUpWithError() throws {
+        DIContainer.shared.inject(.testValue)
         viewModel = RecordViewModel(output: .init(album: .init(value: .initialValue)))
         try super.setUpWithError()
     }
@@ -41,14 +42,7 @@ final class RecordTests: XCTestCase {
 extension RecordTests {
     
     func test_앨범제목입력() throws {
-        
-        // 1. given: 필요한 모든 값 설정
         let (input, output) = makeInputOutput()
-        
-        // 2. when: 테스트 중인 코드 실행
-        
-        
-        // 3. then: 에상 결과 확인
         
     }
 }

--- a/poporazziTests/Feature/2.Record/RecordTests.swift
+++ b/poporazziTests/Feature/2.Record/RecordTests.swift
@@ -26,6 +26,7 @@ final class RecordTests: XCTestCase {
     }
     
     typealias TestInput = (
+        viewDidLoad: PublishRelay<Void>,
         selectButtonTapped: PublishRelay<Void>,
         selectCancelButtonTapped: PublishRelay<Void>,
         recentIndexPath: BehaviorRelay<IndexPath>,
@@ -41,9 +42,166 @@ final class RecordTests: XCTestCase {
 
 extension RecordTests {
     
-    func test_앨범제목입력() throws {
+    func test_첫화면진입() throws {
+        let (input, output) = makeInputOutput()
+        let disposeBag = DisposeBag()
+        
+        let noThumbnailExpectaion = XCTestExpectation(description: "더미 Media 전달")
+        let mediaListExpectaion = XCTestExpectation(description: "이미지 포함된 Media 전달")
+        
+        XCTAssertTrue(output.mediaList.value.isEmpty)
+        
+        output.mediaList
+            .skip(1)
+            .subscribe(onNext: { mediaList in
+                XCTAssertTrue(!mediaList.isEmpty)
+                noThumbnailExpectaion.fulfill()
+            })
+            .disposed(by: disposeBag)
+        
+        output.updateRecordCells
+            .skip(1)
+            .subscribe(onNext: { orderedMediaList in
+                XCTAssertTrue(!orderedMediaList.isEmpty)
+                mediaListExpectaion.fulfill()
+            })
+            .disposed(by: disposeBag)
+        
+        input.viewDidLoad.accept(())
+        
+        wait(for: [noThumbnailExpectaion, mediaListExpectaion], timeout: 1.0)
+    }
+    
+    func test_화면리프레쉬() throws {
+        let (_, output) = makeInputOutput()
+        let disposeBag = DisposeBag()
+        
+        let dummys: [Media] = (0..<300).map { Media(id: String($0), mediaType: .photo) }
+        output.mediaList.accept(dummys)
+        
+        output.mediaList
+            .skip(1)
+            .subscribe(onNext: { mediaList in
+                XCTAssertTrue(!mediaList.isEmpty)
+                XCTAssertTrue(dummys != mediaList)
+            })
+            .disposed(by: disposeBag)
+        
+        output.viewDidRefresh.accept(())
+    }
+    
+    func test_페이지네이션() throws {
+        let (input, output) = makeInputOutput()
+        let disposeBag = DisposeBag()
+        
+        let expectation = XCTestExpectation(description: "페이지네이션 횟수 카운트")
+        expectation.expectedFulfillmentCount = 2
+        
+        let dummys: [Media] = (0..<300).map { Media(id: String($0), mediaType: .photo) }
+        output.mediaList.accept(dummys)
+        
+        output.updateRecordCells
+            .skip(1)
+            .subscribe(onNext: { orderedMediaList in
+                XCTAssertTrue(!orderedMediaList.isEmpty)
+                expectation.fulfill()
+            })
+            .disposed(by: disposeBag)
+        
+        input.recentIndexPath.accept(IndexPath(row: 20, section: 0))
+        input.recentIndexPath.accept(IndexPath(row: 80, section: 0))
+        input.recentIndexPath.accept(IndexPath(row: 90, section: 0))
+        input.recentIndexPath.accept(IndexPath(row: 189, section: 0))
+        input.recentIndexPath.accept(IndexPath(row: 200, section: 0))
+        
+        wait(for: [expectation], timeout: 2.0)
+    }
+    
+    func test_선택모드진입() throws {
+        let (input, output) = makeInputOutput()
+        let disposeBag = DisposeBag()
+        
+        input.selectButtonTapped.accept(())
+        
+        output.switchSelectMode
+            .subscribe(onNext: { bool in
+                XCTAssertTrue(bool)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func test_선택모드취소() throws {
+        let (input, output) = makeInputOutput()
+        let disposeBag = DisposeBag()
+        
+        input.selectCancelButtonTapped.accept(())
+        
+        output.switchSelectMode
+            .subscribe(onNext: { bool in
+                XCTAssertFalse(bool)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func test_셀탭이벤트() throws {
         let (input, output) = makeInputOutput()
         
+        input.recordCellSelected.accept(.init(row: 0, section: 0))
+        input.recordCellSelected.accept(.init(row: 1, section: 0))
+        input.recordCellSelected.accept(.init(row: 2, section: 0))
+        
+        input.recordCellDeselected.accept(.init(row: 1, section: 0))
+        input.recordCellDeselected.accept(.init(row: 2, section: 0))
+        
+        XCTAssertTrue(output.selectedRecordCells.value.count == 1)
+        XCTAssertTrue(output.selectedRecordCells.value.first! == .init(row: 0, section: 0))
+    }
+    
+    func test_기록종료_미디어없음() throws {
+        let (_, output) = makeInputOutput()
+        let disposeBag = DisposeBag()
+        
+        output.mediaList.accept([])
+        
+        let expectation = expectation(description: "뒤로가기")
+        
+        viewModel.navigation
+            .subscribe(onNext: { navigation in
+                if case .pop = navigation {
+                    expectation.fulfill()
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.alertAction.accept(.save)
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertTrue(UserDefaultsService.excludeAssets.isEmpty)
+        XCTAssertTrue(!UserDefaultsService.isTracking)
+    }
+    
+    func test_기록종료_미디어있음() throws {
+        let (_, output) = makeInputOutput()
+        let disposeBag = DisposeBag()
+        
+        output.mediaList.accept([.init(id: "0", mediaType: .photo)])
+        
+        let expectation = expectation(description: "앨범 저장 완료 Alert")
+        
+        output.alertPresented
+            .subscribe(onNext: { _ in
+                expectation.fulfill()
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.alertAction.accept(.save)
+        viewModel.alertAction.accept(.popToHome)
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertTrue(UserDefaultsService.excludeAssets.isEmpty)
+        XCTAssertTrue(!UserDefaultsService.isTracking)
     }
 }
 
@@ -53,6 +211,7 @@ extension RecordTests {
     
     func makeInputOutput() -> (TestInput, RecordViewModel.Output) {
         let testInput = TestInput(
+            viewDidLoad: PublishRelay<Void>(),
             selectButtonTapped: PublishRelay<Void>(),
             selectCancelButtonTapped: PublishRelay<Void>(),
             recentIndexPath: BehaviorRelay<IndexPath>(value: .init(row: 0, section: 0)),
@@ -64,7 +223,7 @@ extension RecordTests {
         )
         
         let input = RecordViewModel.Input(
-            viewDidLoad: .just(()),
+            viewDidLoad: testInput.viewDidLoad.asSignal(),
             selectButtonTapped: testInput.selectButtonTapped.asSignal(),
             selectCancelButtonTapped: testInput.selectCancelButtonTapped.asSignal(),
             recentIndexPath: testInput.recentIndexPath,

--- a/poporazziTests/TitleInputTests.swift
+++ b/poporazziTests/TitleInputTests.swift
@@ -1,0 +1,49 @@
+//
+//  TitleInputTests.swift
+//  poporazziTests
+//
+//  Created by 김민준 on 5/7/25.
+//
+
+import XCTest
+import RxSwift
+import RxCocoa
+@testable import poporazzi
+
+final class TitleInputTests: XCTestCase {
+    
+    private var viewModel: TitleInputViewModel!
+    
+    /// 각각의 Test Method를 실행하기 전에 모든 상태를 reset해주는 함수
+    override func setUpWithError() throws {
+        viewModel = TitleInputViewModel(output: .init())
+        try super.setUpWithError()
+    }
+    
+    /// 각각의 Test Method들이 끝나고 난 뒤에 cleanup을 수행해주는 함수
+    override func tearDownWithError() throws {
+        viewModel = nil
+        try super.tearDownWithError()
+    }
+    
+    /// 테스트 메소드의 이름은 항상 'test'로 시작하고
+    /// 뒤에는 무엇을 테스트하는지 설명해줘야한다.
+    func test_앨범제목입력() throws {
+        
+        // 1. given: 필요한 모든 값 설정
+        let titleTextChanged = PublishRelay<String>()
+        let startButtonTapped = PublishRelay<Void>()
+        let input = TitleInputViewModel.Input(
+            titleTextChanged: titleTextChanged.asSignal(),
+            startButtonTapped: startButtonTapped.asSignal()
+        )
+        let output = viewModel.transform(input)
+        
+        // 2. when: 테스트 중인 코드 실행
+        titleTextChanged.accept("콜드플레이 내한 콘서트")
+        
+        // 3. then: 에상 결과 확인
+        XCTAssertEqual(output.titleText.value, "콜드플레이 내한 콘서트")
+        XCTAssertTrue(output.isStartButtonEnabled.value)
+    }
+}


### PR DESCRIPTION
close #66

## *⛳️ Work Description*
- Unit Test Target 추가
- LiveActivity, PhotoKit 인터페이스 구현 및 Mock 객체 생성
- DI Container 내 liveValue, testValue 주입 구현
- TitleInputViewModel, RecordViewModel Unit Test 작성

## *🧐 트러블슈팅*
### 1. Unit Test Target 추가
추후 Xcode Cloude를 활용한 CI/CD를 적용하기 위해, MVVM 아키텍처를 채택한 이유를 살리기 위해 Unit Test를 계획했습니다. Unit Test는 이전에 Swift Test를 활용 + TCA의 TestStore를 활용한 UnitTest를 진행한 경험이 있었습니다. 경험해보지 않은 툴을 사용해보고 싶어 XCTest를 채택했습니다. 

### 2. XCTest 간단하게 알아보기
XCTest를 시작하기 위해 세팅해야할 것은 3가지입니다.
1. setUp
2. tearDown
3. test method

~~~swift
import XCTest
@testable import poporazzi // ⭐️ 메인 모듈에 접근할 수 있게 만들어줌

final class TitleInputTests: XCTestCase { // ⭐️ XCTestCase 상속 받기
    
    private var viewModel: TitleInputViewModel!
    
    // ⭐️ 1. 사용할 객체 초기화
    // 각 테스트 간의 독립성을 보장하기 위해 초기화를 하는 것!
    override func setUpWithError() throws {
        viewModel = TitleInputViewModel(output: .init())
        try super.setUpWithError()
    }
    
    // ⭐️ 2. 모두 사용했으면 객체 해제 해줌
    // 이 또한 테스트 간 독립성을 보장하기 위함
    override func tearDownWithError() throws {
        viewModel = nil
        try super.tearDownWithError()
    }
    
    // ⭐️ 3. 실제 테스트 함수 작성
    func test_첫번째테스트() throws {
        // doSomething...
    }
}
~~~

각 테스트 간의 독립성을 보장하기 위해(viewModel은 매 테스트에서 사용하기 때문) setup, tearDown을 작성했다면 다음은 Unit Test를 작성하면 됩니다. 아래는 XCTest의 UnitTest를 작성한 간단한 예시입니다.

~~~swift
func test_앨범제목입력() throws {

    // 1. given: 테스트 값 세팅
    let (input, output) = makeInputOutput()
    
    // 2. when: 이벤트 및 조건 실행
    let testTitle = "콜드플레이 내한 콘서트"
    input.titleTextChanged.accept(testTitle)
    
    // 3. then: 결과 검증
    XCTAssertEqual(output.titleText.value, testTitle)
    XCTAssertTrue(output.isStartButtonEnabled.value)
}
~~~

조금 더 복잡하게 들어가 비동기 값에 대한 처리가 필요할 때는 `XCTestExpectation`를 활용할 수 있습니다.

~~~swift
func test_페이지네이션() throws {
    let (input, output) = makeInputOutput()
    let disposeBag = DisposeBag()
    
    // ⭐️ 비동기로 처리할 테스트 검증 값
    let expectation = XCTestExpectation(description: "페이지네이션 횟수 카운트")
    expectation.expectedFulfillmentCount = 2 // ⭐️ 총 2번 검증 설정
    
    let dummys: [Media] = (0..<300).map { Media(id: String($0), mediaType: .photo) }
    output.mediaList.accept(dummys)
    
    output.updateRecordCells
        .skip(1)
        .subscribe(onNext: { orderedMediaList in
            XCTAssertTrue(!orderedMediaList.isEmpty)
            expectation.fulfill() // ⭐️ 조건이 성립할 때 expectation 확인
        })
        .disposed(by: disposeBag)
    
    input.recentIndexPath.accept(IndexPath(row: 20, section: 0))
    input.recentIndexPath.accept(IndexPath(row: 80, section: 0))
    input.recentIndexPath.accept(IndexPath(row: 90, section: 0))
    input.recentIndexPath.accept(IndexPath(row: 189, section: 0))
    input.recentIndexPath.accept(IndexPath(row: 200, section: 0))
    
    // ⭐️ 배열에 담긴 예상 결과를 2초 동안 대기
    wait(for: [expectation], timeout: 2.0)
}
~~~

### 3. Mock 객체 주입을 위한 Interface 설계
포포라치는 현재 2개의 주요 의존성 객체를 사용하고 있습니다. LiveActivityService와 PhotoKitService는 핵심 비즈니스 로직을 위한 필수구현체로서, ViewModel 곳곳에서 사용되고 있습니다. 즉, ViewModel의 Unit Test를 위해서는 의존성 컨트롤이 필요하게 됩니다. 실제 Live Activity나 PhotoKit의 에셋 조작 기능은 Unit Test하기 어렵기 때문에 이를 Mock 객체로 만들어주는 과정이 필요합니다.
~~~swift
protocol LiveActivityInterface {
    
    /// Live Activity를 시작합니다.
    func start(to album: Album)
    
    /// Live Activity를 업데이트합니다.
    func update(to album: Album, totalCount: Int)
    
    /// Live Activity를 종료합니다.
    func stop()
}

struct MockLiveActivityService: LiveActivityInterface {
    func start(to album: Album) {
        print("[Live Activity 시작] - \(album.title), \(album.trackingStartDate.startDateFullFormat)")
    }
    
    func update(to album: Album, totalCount: Int) {
        print("[Live Activity 업데이트] - \(album.title), \(album.trackingStartDate.startDateFullFormat), 총\(totalCount)개")
    }
    
    func stop() {
        print("[Live Activity 종료]")
    }
}
~~~

위 처럼 테스트 객체를 만들고 DI Container를 통해 Mock 객체를 주입해주면 Unit Test 환경에서는 Mock 객체를, 실제 구동에서는 Live 객체를 사용할 수 있게 됩니다.

~~~swift
extension DIContainer {
    
    /// 주입 할 객체를 반환합니다.
    enum InjectObject {
        case liveValue
        case testValue
        
        /// 의존성 객체
        var dependencies: Dependencies {
            switch self {
            case .liveValue: .init(
                liveActivityService: LiveActivityService(),
                photoKitService: PhotoKitService()
            )
            case .testValue: .init(
                liveActivityService: MockLiveActivityService(),
                photoKitService: MockPhotoKitService()
            )
            }
        }
    }
    
    /// 의존성을 주입합니다.
    func inject(_ injectObject: InjectObject) {
        dependencies = injectObject.dependencies
    }
}
~~~

~~~swift
final class TitleInputTests: XCTestCase {
    
    private var viewModel: TitleInputViewModel!
    
    override func setUpWithError() throws {
        DIContainer.shared.inject(.testValue) // ⭐️ Unit Test 환경에서는 테스트 객체 주입
        viewModel = TitleInputViewModel(output: .init())
        try super.setUpWithError()
    }
}
~~~

### 4. 유닛 테스트 진행 결과
아래는 TitleInputViewModel과 RecordViewModel의 Test Coverage입니다. Unit Test 작성 이전 0%, 56.1%의 Coverage를 Unit Test 작성 이후 72.4%, 71.1%까지 끌어올릴 수 있었습니다.
![image](https://github.com/user-attachments/assets/06aee583-8b2a-4255-8ef8-8411d8280786)

추후 ViewModel을 기반으로 전체 화면의 Unit Test를 진행하고 CI로 통합시킬 예정입니다.

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|유닛테스트 작성 및 통과|<img width="300" alt="" src="https://github.com/user-attachments/assets/7bc2556a-ab8c-44a6-b9d0-fde0e4c7e75b">|