### PR TITLE
앨범 저장 오류 해결

### DIFF
--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -31,7 +31,7 @@ struct MockPhotoKitService: PhotoKitInterface {
         return .just(array)
     }
     
-    func saveAlbum(title: String) throws {
+    func saveAlbum(title: String, excludeAssets: [String]) throws {
         print("[앨범 저장 완료] - \(title)")
     }
     

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -28,7 +28,7 @@ protocol PhotoKitInterface {
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]>
     
     /// 현재 fetchResult를 기준으로 앨범을 저장합니다.
-    func saveAlbum(title: String) throws
+    func saveAlbum(title: String, excludeAssets: [String]) throws
     
     /// 사진을 삭제 후 결과 이벤트를 반환합니다.
     func deletePhotos(from assetIdentifiers: [String]) -> Observable<Bool>

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -359,7 +359,7 @@ extension RecordViewModel {
     /// 앨범에 저장합니다.
     private func saveToAlbums() throws {
         let title = output.album.value.title
-        try photoKitService.saveAlbum(title: title)
+        try photoKitService.saveAlbum(title: title, excludeAssets: UserDefaultsService.excludeAssets)
     }
 }
 


### PR DESCRIPTION
close #68

## *⛳️ Work Description*
- 동일한 이름의 앨범 생성 시, 저장 후 덮어씌워지는 문제 해결
- 제외된 기록이 추가되었음에도 종료 시 반영되지 않는 문제 해결

## *🧐 트러블슈팅*
### 1. 동일한 이름의 앨범 생성 시, 저장 후 덮어씌워지는 문제 해결
만약 '제주도 여행'이라는 앨범이 이전에 생성되고 이후 동일한 이름의 앨범 이름으로 기록을 종료할 시, 기존의 생성되어있던 '제주도 여행' 앨범에 사진이 덮어씌워지는 현상이 발생했습니다. 이는 개발 초기에 엣지 케이스를 추후 개발로 미뤄두고 놓치고 있었던 부분이었습니다.

또한 앨범 제목을 기준으로  PHAssetCollection을 불러오고 있었기 때문에, 제목 이외의 앨범을 식별할 수 있는 값이 필요했습니다.
~~~swift
/// 앨범에 기록을 저장합니다.
func saveAlbum(title: String) throws {
    guard let assets = fetchResult else { throw PhotoKitError.emptyAssets }
    
    // 기존 앨범에 추가
    if let album = fetchAlbum(title: title) { // ⭐️ 기존의 앨범 반환은 제목을 기준으로만 실행
        appendToAlbum(assets: assets, to: album) 
    }
    
    // 앨범 새로 생성
    else {
        PHPhotoLibrary.shared().performChanges {
            PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: title)
        } completionHandler: { [weak self] isSuccess, error in
            guard let self else { return }
            guard let album = fetchAlbum(title: title) else { return } // ⭐️ 기존의 앨범 반환은 제목을 기준으로만 실행
            appendToAlbum(assets: assets, to: album)
        }
    }
}
~~~

이를 해결하기 위해 앨범 생성과 동시에 request 값이 가지고 있는 placeholder의 localIdentifier 값을 이용해 직전에 생성한 앨범을 식별함으로써 해당 문제를 해결할 수 있었습니다.

~~~swift
/// 앨범에 기록을 저장합니다.
func saveAlbum(title: String, excludeAssets: [String]) throws {
    guard let filteredFetchResult = try filterExcludeAssets(excludeAssets) else { return }
    
    var albumIdentifier: String? // ⭐️ 앨범의 Identifier를 저장할 변수
    
    PHPhotoLibrary.shared().performChanges {
        let request = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: title)
        albumIdentifier = request.placeholderForCreatedAssetCollection.localIdentifier // ⭐️ 앨범 생성 Request에서 반환되는 placeholder의 Identifier 저장
    } completionHandler: { [weak self] isSuccess, error in
        guard let self else { return }
        guard isSuccess, let albumIdentifier else { return }
        guard let album = fetchAlbum(from: albumIdentifier) else { return } // ⭐️ 저장한 Identifier를 사용해 앨범 식별
        appendToAlbum(filteredFetchResult, to: album)
    }
}
~~~

### 2. 제외된 기록이 추가되었음에도 종료 시 반영되지 않는 문제 해결
제외된 앨범은 포포라치 화면 상에서는 정상적으로 반영되었지만, 앨범에 저장할 때에는 미반영 되는 현상이 있었습니다. 이는 PhotoKitService 내부에서 `fetchResult`를 캐시해 사용하고, 이를 그대로 앨범 저장 시에 사용했기 때문에 발생한 문제였습니다.

~~~swift
/// 앨범에 기록을 저장합니다.
func saveAlbum(title: String) throws {

    // ⭐️ PhotoKitService가 전역적으로 들고 있는 fetchResult를 이용해 그대로 사용하고 있었음
    guard let assets = fetchResult else { throw PhotoKitError.emptyAssets }
    
    // 기존 앨범에 추가
    if let album = fetchAlbum(title: title) {
        appendToAlbum(assets: assets, to: album)
    }
    
    // 앨범 새로 생성
    else {
        PHPhotoLibrary.shared().performChanges {
            PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: title)
        } completionHandler: { [weak self] isSuccess, error in
            guard let self else { return }
            guard let album = fetchAlbum(title: title) else { return }
            appendToAlbum(assets: assets, to: album)
        }
    }
}
~~~

이를 해결하기 위해 saveAlbum 함수의 인자로 제외된 에셋 배열을 받아오고, 이를 필터링에 사용함으로써 문제를 해결할 수 있었습니다. 추가로 
`PHFetchResult<PHAsset>`는 직접적으로 필터링 할 수 없기 때문에, 이를 `[PHAsset]`으로 변환 후 필터링하고 이를 다시 `PHFetchResult<PHAsset>`으로 변환 시켜줄 수 있도록 구현했습니다.

~~~swift
/// 앨범에 기록을 저장합니다.
func saveAlbum(title: String, excludeAssets: [String]) throws {

    // ⭐️ 필터링한 PHFetchResult<PHAsset>을 사용
    guard let filteredFetchResult = try filterExcludeAssets(excludeAssets) else { return }
    
    var albumIdentifier: String?
    
    PHPhotoLibrary.shared().performChanges {
        let request = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: title)
        albumIdentifier = request.placeholderForCreatedAssetCollection.localIdentifier
    } completionHandler: { [weak self] isSuccess, error in
        guard let self else { return }
        guard isSuccess, let albumIdentifier else { return }
        guard let album = fetchAlbum(from: albumIdentifier) else { return }
        appendToAlbum(filteredFetchResult, to: album)
    }
}

/// 현재 에셋을 필터링 후 반환합니다.
private func filterExcludeAssets(_ excludeAssets: [String]) throws -> PHFetchResult<PHAsset>? {
    guard let fetchResult else { throw PhotoKitError.emptyAssets }
    
    // ⭐️ FetchResult를 [PHAsset]으로 변환
    let allAssets = (0..<fetchResult.count).compactMap { fetchResult.object(at: $0) }
    
    // ⭐️ [PHAsset]을 필터링하고 다시 localIdentifier로 변환
    let filteredIdentifiers = allAssets
        .filter { !Set(excludeAssets).contains($0.localIdentifier) }
        .map { $0.localIdentifier }
    
    // ⭐️ fetchResult를 직접적으로 순회하는 것은 순서를 보장해주지 않기 때문에, 시간순으로 재정렬 후 반환
    let fetchOptions = PHFetchOptions()
    fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
    return PHAsset.fetchAssets(withLocalIdentifiers: filteredIdentifiers, options: fetchOptions)
}
~~~