### PR TITLE
앨범 일차 별 분리 기능 구현

### DIFF
--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -20,13 +20,13 @@ struct MockPhotoKitService: PhotoKitInterface {
     }
     
     func fetchMediasWithNoThumbnail(mediaFetchType: MediaFetchType, date: Date, ascending: Bool) -> [Media] {
-        Array(repeatElement(Media(id: UUID().uuidString, mediaType: .photo), count: 30))
+        Array(repeatElement(Media(id: UUID().uuidString, creationDate: .now, mediaType: .photo), count: 30))
     }
     
-    func fetchMedias(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]> {
-        var array = [OrderedMedia]()
+    func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]> {
+        var array = [Media]()
         for i in 0..<30 {
-            array.append((i, Media(id: UUID().uuidString, mediaType: .photo, thumbnail: UIImage())))
+            array.append(Media(id: UUID().uuidString, creationDate: .now, mediaType: .photo, thumbnail: UIImage()))
         }
         return .just(array)
     }

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -26,9 +26,6 @@ struct Media: Hashable, Equatable {
     }
 }
 
-/// 순서 보장이 필요한 Media 튜플
-typealias OrderedMedia = (Int, Media)
-
 /// 미디어 타입
 enum MediaType: Hashable {
     case photo

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -9,8 +9,10 @@ import UIKit
 
 /// 미디어
 struct Media: Hashable, Equatable {
-    var id: String
-    var mediaType: MediaType
+    
+    let id: String
+    let creationDate: Date?
+    let mediaType: MediaType
     var thumbnail: UIImage?
     
     func hash(into hasher: inout Hasher) {
@@ -38,4 +40,12 @@ enum MediaFetchType {
     case all
     case image
     case video
+}
+
+extension [Media] {
+    
+    /// 날짜순으로 정렬 후 반환합니다.
+    var sortedByCreationDate: [Media] {
+        sorted { $0.creationDate ?? Date() < $1.creationDate ?? Date() }
+    }
 }

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -25,7 +25,7 @@ protocol PhotoKitInterface {
     ) -> [Media]
     
     /// Media 배열 이벤트를 반환합니다.
-    func fetchMedias(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]>
+    func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]>
     
     /// 현재 fetchResult를 기준으로 앨범을 저장합니다.
     func saveAlbum(title: String, excludeAssets: [String]) throws

--- a/poporazzi/Feature/2.Record/RecordView.swift
+++ b/poporazzi/Feature/2.Record/RecordView.swift
@@ -113,7 +113,7 @@ final class RecordView: CodeBaseUI {
     let recordCollectionView: UICollectionView = {
         let collectionView = UICollectionView(
             frame: .zero,
-            collectionViewLayout: CollectionViewLayout.threeColumns
+            collectionViewLayout: CollectionViewLayout.threeColumnsWithHeader
         )
         collectionView.backgroundColor = .white
         collectionView.allowsSelection = false

--- a/poporazzi/Feature/2.Record/RecordViewController.swift
+++ b/poporazzi/Feature/2.Record/RecordViewController.swift
@@ -84,7 +84,7 @@ extension RecordViewController {
             if let section = self?.dataSource.sectionIdentifier(for: indexPath.section) {
                 switch section {
                 case let .day(order, date):
-                    header?.action(.updateDayCountLabel("\(order)일차"))
+                    header?.action(.updateDayCountLabel(order))
                     header?.action(.updateDateLabel(date))
                 }
             }

--- a/poporazzi/Feature/2.Record/RecordViewController.swift
+++ b/poporazzi/Feature/2.Record/RecordViewController.swift
@@ -87,7 +87,7 @@ extension RecordViewController {
     }
     
     /// 기본 DataSource를 업데이트합니다.
-    private func updateInitialDataSource(to sections: [(Date, [Media])]) {
+    private func updateInitialDataSource(to sections: SectionMediaList) {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Media>()
         let sections = sections.map { (Section.day($0), $1)}
         for (section, medias) in sections {
@@ -151,7 +151,7 @@ extension RecordViewController {
             }
             .disposed(by: disposeBag)
         
-        output.setupInitialData
+        output.sectionMediaList
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, sections in
                 owner.updateInitialDataSource(to: sections)

--- a/poporazzi/Feature/2.Record/RecordViewController.swift
+++ b/poporazzi/Feature/2.Record/RecordViewController.swift
@@ -9,17 +9,6 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-enum RecordSection: Hashable, Comparable {
-    case day(order: Int, date: Date)
-    
-    static func < (lhs: RecordSection, rhs: RecordSection) -> Bool {
-        switch (lhs, rhs) {
-        case let (.day(order1, _), .day(order2, _)):
-            return order1 < order2
-        }
-    }
-}
-
 final class RecordViewController: ViewController {
     
     private let scene = RecordView()
@@ -48,6 +37,21 @@ final class RecordViewController: ViewController {
     
     deinit {
         Log.print(#file, .deinit)
+    }
+}
+
+// MARK: - RecordSection
+
+typealias SectionMediaList = [(RecordSection, [Media])]
+
+enum RecordSection: Hashable, Comparable {
+    case day(order: Int, date: Date)
+    
+    static func < (lhs: RecordSection, rhs: RecordSection) -> Bool {
+        switch (lhs, rhs) {
+        case let (.day(order1, _), .day(order2, _)):
+            return order1 < order2
+        }
     }
 }
 

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-typealias SectionMediaList = [(Date, [Media])]
+typealias SectionMediaList = [(RecordSection, [Media])]
 
 final class RecordViewModel: ViewModel {
     
@@ -332,17 +332,28 @@ extension RecordViewModel {
         }
     }
     
+    /// 시작날짜를 기준으로 생성일이 몇일차인지 반환합니다.
+    private func days(from creationDate: Date) -> Int {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents(
+            [.day],
+            from: calendar.startOfDay(for: output.album.value.trackingStartDate),
+            to: calendar.startOfDay(for: creationDate)
+        )
+        return (components.day ?? 0) + 1
+    }
+    
     /// 날짜 별로 MediaList를 분리해 반환합니다.
     private func dayCountSections(from allMediaList: [Media]) -> SectionMediaList {
-        let calendar = Calendar.current
-        var dic = [Date: [Media]]()
+        var dic = [RecordSection: [Media]]()
         
         for media in allMediaList.sortedByCreationDate {
             guard let creationDate = media.creationDate else { continue }
-            let components = calendar.dateComponents([.year, .month, .day], from: creationDate)
-            if let dayOnlyDate = calendar.date(from: components) {
-                dic[dayOnlyDate, default: []].append(media)
-            }
+            let days = days(from: creationDate)
+            dic[.day(
+                order: days,
+                date: Calendar.current.startOfDay(for: creationDate)
+            ), default: []].append(media)
         }
         
         return dic.keys

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -55,7 +55,7 @@ extension RecordViewModel {
     struct Output {
         let album: BehaviorRelay<Album>
         let mediaList = BehaviorRelay<[Media]>(value: [])
-        let updateRecordCells = BehaviorRelay<[OrderedMedia]>(value: [])
+        let updateRecordCells = BehaviorRelay<[Media]>(value: [])
         let selectedRecordCells = BehaviorRelay<[IndexPath]>(value: [])
         let viewDidRefresh = PublishRelay<Void>()
         let setupSeeMoreMenu = BehaviorRelay<[MenuModel]>(value: [])
@@ -132,8 +132,8 @@ extension RecordViewModel {
                 
                 let assetIdentifiers = owner.chunkAssetIdentifiers
                 owner.requestImages(from: assetIdentifiers)
-                    .bind { orderedMediaList in
-                        owner.output.updateRecordCells.accept(orderedMediaList)
+                    .bind { mediaList in
+                        owner.output.updateRecordCells.accept(mediaList)
                     }
                     .disposed(by: owner.disposeBag)
             }
@@ -152,15 +152,8 @@ extension RecordViewModel {
                     let assetIdentifiers = owner.chunkAssetIdentifiers
                     
                     owner.requestImages(from: assetIdentifiers)
-                        .bind { orderedMediaList in
-                            let indexPathMediaList = orderedMediaList.map { (index, media) in
-                                OrderedMedia(
-                                    index: owner.currentChunk + index,
-                                    media: media
-                                )
-                            }
-                            
-                            owner.output.updateRecordCells.accept(indexPathMediaList)
+                        .bind { mediaList in
+                            owner.output.updateRecordCells.accept(mediaList)
                         }
                         .disposed(by: owner.disposeBag)
                 }
@@ -352,7 +345,7 @@ extension RecordViewModel {
     }
     
     /// Asset Identifiers에 대응되는 Media 스트림을 반환합니다.
-    private func requestImages(from assetIdentifiers: [String]) -> Observable<[OrderedMedia]> {
+    private func requestImages(from assetIdentifiers: [String]) -> Observable<[Media]> {
         photoKitService.fetchMedias(from: assetIdentifiers)
     }
     

--- a/poporazzi/Feature/2.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/RecordViewModel.swift
@@ -10,8 +10,6 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-typealias SectionMediaList = [(RecordSection, [Media])]
-
 final class RecordViewModel: ViewModel {
     
     @Dependency(\.liveActivityService) private var liveActivityService

--- a/poporazzi/Feature/5.ExcludeRecord/ExcludeRecordViewModel.swift
+++ b/poporazzi/Feature/5.ExcludeRecord/ExcludeRecordViewModel.swift
@@ -174,7 +174,7 @@ extension ExcludeRecordViewModel {
     /// 제외된 사진을 반환합니다.
     private func fetchExcludePhotos() -> Observable<[Media]> {
         let assetIdentifiers = UserDefaultsService.excludeAssets
-        return photoKitService.fetchMedias(from: assetIdentifiers).map { $0.map { $0.1 } }
+        return photoKitService.fetchMedias(from: assetIdentifiers)
     }
 }
 

--- a/poporazzi/UIComponent/RecordCell.swift
+++ b/poporazzi/UIComponent/RecordCell.swift
@@ -16,7 +16,11 @@ final class RecordCell: UICollectionViewCell {
     var containerView = UIView()
     
     /// 영상 전용 오버레이
-    private let videoOverlay = UIView()
+    private let videoOverlay: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        return view
+    }()
     
     /// 선택 전용 오버레이
     private let selectOverlay: UIView = {
@@ -37,7 +41,7 @@ final class RecordCell: UICollectionViewCell {
     /// 영상 전용 그라디언트 레이어
     private let videoGradientLayer: CAGradientLayer = {
         let gradientLayer = CAGradientLayer()
-        gradientLayer.colors = [UIColor.clear.cgColor, UIColor.brandPrimary.withAlphaComponent(0.4).cgColor]
+        gradientLayer.colors = [UIColor.clear.cgColor, UIColor.mainLabel.withAlphaComponent(0.4).cgColor]
         gradientLayer.locations = [0.0, 1.0]
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.5)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
@@ -142,12 +146,13 @@ extension RecordCell {
 extension RecordCell {
     
     func configLayout() {
+        let cornerRadius: CGFloat = 8
         containerView.flex.define { flex in
-            flex.addItem(thumbnail).grow(1)
+            flex.addItem(thumbnail).cornerRadius(cornerRadius).grow(1)
             flex.addItem(checkIcon).position(.absolute).top(8).left(8)
         }
         
-        videoOverlay.flex.define { flex in
+        videoOverlay.flex.cornerRadius(cornerRadius).define { flex in
             flex.addItem(videoDurationLabel).position(.absolute).bottom(6).right(10)
         }
     }

--- a/poporazzi/UIComponent/RecordHeader.swift
+++ b/poporazzi/UIComponent/RecordHeader.swift
@@ -77,7 +77,7 @@ extension RecordHeader {
 extension RecordHeader {
     
     func configLayout() {
-        containerView.flex.direction(.row).paddingLeft(20).define { flex in
+        containerView.flex.direction(.row).paddingLeft(4).define { flex in
             flex.addItem(dayCountLabel)
             flex.addItem(dateLabel).marginLeft(8)
         }

--- a/poporazzi/UIComponent/RecordHeader.swift
+++ b/poporazzi/UIComponent/RecordHeader.swift
@@ -19,7 +19,7 @@ final class RecordHeader: UICollectionReusableView {
     private let dayCountLabel: UILabel = {
         let label = UILabel()
         label.textColor = .mainLabel
-        label.font = .setDovemayo(18)
+        label.font = .setDovemayo(20)
         return label
     }()
     
@@ -27,7 +27,7 @@ final class RecordHeader: UICollectionReusableView {
     private let dateLabel: UILabel = {
         let label = UILabel()
         label.textColor = .subLabel
-        label.font = .setDovemayo(14)
+        label.font = .setDovemayo(16)
         return label
     }()
     

--- a/poporazzi/UIComponent/RecordHeader.swift
+++ b/poporazzi/UIComponent/RecordHeader.swift
@@ -54,16 +54,20 @@ extension RecordHeader {
     
     enum Action {
         case updateDayCountLabel(String)
-        case updateDateLabel(String)
+        case updateDateLabel(Date)
     }
     
     func action(_ action: Action) {
         switch action {
         case .updateDayCountLabel(let string):
+            dayCountLabel.flex.markDirty()
             dayCountLabel.text = string
+            setNeedsLayout()
             
-        case .updateDateLabel(let string):
-            dateLabel.text = string
+        case .updateDateLabel(let date):
+            dateLabel.flex.markDirty()
+            dateLabel.text = date.sectionHeaderFormat
+            setNeedsLayout()
         }
     }
 }

--- a/poporazzi/UIComponent/RecordHeader.swift
+++ b/poporazzi/UIComponent/RecordHeader.swift
@@ -53,15 +53,15 @@ final class RecordHeader: UICollectionReusableView {
 extension RecordHeader {
     
     enum Action {
-        case updateDayCountLabel(String)
+        case updateDayCountLabel(Int)
         case updateDateLabel(Date)
     }
     
     func action(_ action: Action) {
         switch action {
-        case .updateDayCountLabel(let string):
+        case .updateDayCountLabel(let order):
             dayCountLabel.flex.markDirty()
-            dayCountLabel.text = string
+            dayCountLabel.text = "\(order)일차"
             setNeedsLayout()
             
         case .updateDateLabel(let date):

--- a/poporazzi/Utility/CollectionViewLayout+.swift
+++ b/poporazzi/Utility/CollectionViewLayout+.swift
@@ -37,7 +37,7 @@ struct CollectionViewLayout {
         
         // 4. 섹션 설정
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.contentInsets = .init(top: 10, leading: 0, bottom: 32, trailing: 0)
         
         return section
     }

--- a/poporazzi/Utility/CollectionViewLayout+.swift
+++ b/poporazzi/Utility/CollectionViewLayout+.swift
@@ -9,8 +9,7 @@ import UIKit
 
 struct CollectionViewLayout {
     
-    /// 기본 3단 레이아웃을 반환합니다.
-    static var threeColumns: UICollectionViewCompositionalLayout {
+    private static var section: NSCollectionLayoutSection {
         
         // 1. 기본값 변수 저장
         let numberOfRows: CGFloat = 3
@@ -38,9 +37,22 @@ struct CollectionViewLayout {
         
         // 4. 섹션 설정
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 10, leading: 0, bottom: 28, trailing: 0)
+        section.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
         
-        // 5. 헤더 설정
+        return section
+    }
+    
+    /// 기본 3단 레이아웃을 반환합니다.
+    static var threeColumns: UICollectionViewCompositionalLayout {
+        UICollectionViewCompositionalLayout(section: section)
+    }
+    
+    /// Header가 포함된 기본 3단 레이아웃을 반환합니다.
+    static var threeColumnsWithHeader: UICollectionViewCompositionalLayout {
+        
+        let headerSection = section
+        
+        // 헤더 설정
         let headerSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1),
             heightDimension: .absolute(32)
@@ -50,8 +62,8 @@ struct CollectionViewLayout {
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
-        section.boundarySupplementaryItems = [header]
+        headerSection.boundarySupplementaryItems = [header]
         
-        return UICollectionViewCompositionalLayout(section: section)
+        return UICollectionViewCompositionalLayout(section: headerSection)
     }
 }

--- a/poporazzi/Utility/CollectionViewLayout+.swift
+++ b/poporazzi/Utility/CollectionViewLayout+.swift
@@ -37,7 +37,7 @@ struct CollectionViewLayout {
         
         // 4. 섹션 설정
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 8, leading: 0, bottom: 32, trailing: 0)
+        section.contentInsets = .init(top: 8, leading: 16, bottom: 32, trailing: 16)
         
         return section
     }

--- a/poporazzi/Utility/CollectionViewLayout+.swift
+++ b/poporazzi/Utility/CollectionViewLayout+.swift
@@ -37,7 +37,7 @@ struct CollectionViewLayout {
         
         // 4. 섹션 설정
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 10, leading: 0, bottom: 32, trailing: 0)
+        section.contentInsets = .init(top: 8, leading: 0, bottom: 32, trailing: 0)
         
         return section
     }

--- a/poporazzi/Utility/CollectionViewLayout+.swift
+++ b/poporazzi/Utility/CollectionViewLayout+.swift
@@ -37,7 +37,7 @@ struct CollectionViewLayout {
         
         // 4. 섹션 설정
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
+        section.contentInsets = .init(top: 10, leading: 0, bottom: 0, trailing: 0)
         
         return section
     }

--- a/poporazzi/Utility/Formatter+.swift
+++ b/poporazzi/Utility/Formatter+.swift
@@ -18,6 +18,12 @@ extension Date {
         return formatter
     }()
     
+    /// 날짜 비교용 포맷을 반환합니다.
+    var compareFormat: String {
+        Date.dateFormatter.dateFormat = "yyyy-MM-dd"
+        return Date.dateFormatter.string(from: self)
+    }
+    
     /// 시작 날짜 포맷을 반환합니다.
     var startDateFormat: String {
         Date.dateFormatter.dateFormat = "yyyy년 M월 d일 EEEE~"
@@ -27,6 +33,12 @@ extension Date {
     /// 시작 날짜 전체 포맷을 반환합니다.
     var startDateFullFormat: String {
         Date.dateFormatter.dateFormat = "yyyy년 M월 d일 EEEE a h시 mm분~"
+        return Date.dateFormatter.string(from: self)
+    }
+    
+    /// Section의 Header 포맷을 반환합니다.
+    var sectionHeaderFormat: String {
+        Date.dateFormatter.dateFormat = "M월 d일 EEEE"
         return Date.dateFormatter.string(from: self)
     }
 }

--- a/poporazziTests/Feature/2.Record/RecordTests.swift
+++ b/poporazziTests/Feature/2.Record/RecordTests.swift
@@ -76,7 +76,7 @@ extension RecordTests {
         let (_, output) = makeInputOutput()
         let disposeBag = DisposeBag()
         
-        let dummys: [Media] = (0..<300).map { Media(id: String($0), mediaType: .photo) }
+        let dummys: [Media] = (0..<300).map { Media(id: String($0), creationDate: .now, mediaType: .photo) }
         output.mediaList.accept(dummys)
         
         output.mediaList
@@ -97,7 +97,7 @@ extension RecordTests {
         let expectation = XCTestExpectation(description: "페이지네이션 횟수 카운트")
         expectation.expectedFulfillmentCount = 2
         
-        let dummys: [Media] = (0..<300).map { Media(id: String($0), mediaType: .photo) }
+        let dummys: [Media] = (0..<300).map { Media(id: String($0), creationDate: .now, mediaType: .photo) }
         output.mediaList.accept(dummys)
         
         output.updateRecordCells
@@ -185,7 +185,7 @@ extension RecordTests {
         let (_, output) = makeInputOutput()
         let disposeBag = DisposeBag()
         
-        output.mediaList.accept([.init(id: "0", mediaType: .photo)])
+        output.mediaList.accept([.init(id: "0", creationDate: .now, mediaType: .photo)])
         
         let expectation = expectation(description: "앨범 저장 완료 Alert")
         


### PR DESCRIPTION
close #74

## *⛳️ Work Description*
- RecordView 앨범 일차 별 분리 기능 구현
- Cell UI 업데이트

## *🧐 트러블슈팅*
### 1. 앨범 일차별로 분리하기
시작 날짜를 기준으로 1일차, 12시가 지나면 +1일을 계산하고, 각 Section 내 연관값을 이용해 Header를 업데이트했습니다.
~~~swift
typealias SectionMediaList = [(RecordSection, [Media])] // ⭐️ 섹션별 Media 리스트를 들고 있는 타입

enum RecordSection: Hashable, Comparable {
    case day(order: Int, date: Date) // ⭐️ 연관값을 이용해 몇일차인지, 기준 날짜는 언제인지 전달
}

dataSource.supplementaryViewProvider = {
    [weak self] (collectionView, elementKind, indexPath) -> UICollectionReusableView? in
    let header = collectionView.dequeueReusableSupplementaryView(
        ofKind: elementKind,
        withReuseIdentifier: RecordHeader.identifier,
        for: indexPath
    ) as? RecordHeader
    
    if let section = self?.dataSource.sectionIdentifier(for: indexPath.section) {
        switch section {
        case let .day(order, date):
            header?.action(.updateDayCountLabel(order)) // ⭐️ 일차수 업데이트
            header?.action(.updateDateLabel(date)) // ⭐️ 날짜 업데이트
        }
    }
    
    return header
}
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|일차별 화면 분리|<img width="300" alt="" src="https://github.com/user-attachments/assets/90693cee-9456-4fa5-bd05-df992459125d">|