### PR TITLE
앱스토어 리뷰 Alert 기능 구현

### DIFF
--- a/poporazzi/App/DIContainer.swift
+++ b/poporazzi/App/DIContainer.swift
@@ -20,6 +20,7 @@ final class DIContainer {
     struct Dependencies {
         let liveActivityService: LiveActivityInterface
         let photoKitService: PhotoKitInterface
+        let storeKitService: StoreKitServiceInterface
     }
     
     /// 객체를 꺼내옵니다.
@@ -42,11 +43,13 @@ extension DIContainer {
             switch self {
             case .liveValue: .init(
                 liveActivityService: LiveActivityService(),
-                photoKitService: PhotoKitService()
+                photoKitService: PhotoKitService(),
+                storeKitService: StoreKitService()
             )
             case .testValue: .init(
                 liveActivityService: MockLiveActivityService(),
-                photoKitService: MockPhotoKitService()
+                photoKitService: MockPhotoKitService(),
+                storeKitService: MockStoreKitService()
             )
             }
         }

--- a/poporazzi/Data/Mock/MockStoreKitService.swift
+++ b/poporazzi/Data/Mock/MockStoreKitService.swift
@@ -1,0 +1,16 @@
+//
+//  MockStoreKitService.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/12/25.
+//
+
+import Foundation
+
+struct MockStoreKitService: StoreKitServiceInterface {
+    
+    /// 사용자에게 AppStore 리뷰 Alert를 출력합니다.
+    func requestReview() {
+        print("AppStore 리뷰 Alert 출력")
+    }
+}

--- a/poporazzi/Data/Service/StoreKitService.swift
+++ b/poporazzi/Data/Service/StoreKitService.swift
@@ -1,0 +1,24 @@
+//
+//  StoreKitService.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/12/25.
+//
+
+import StoreKit
+
+struct StoreKitService: StoreKitServiceInterface {
+    
+    /// 사용자에게 AppStore 리뷰 Alert를 출력합니다.
+    func requestReview() {
+        guard let scene = UIApplication.shared.connectedScenes.first(where: {
+            $0.activationState == .foregroundActive
+        }) as? UIWindowScene else { return }
+        
+        Task {
+            await MainActor.run {
+                AppStore.requestReview(in: scene)
+            }
+        }
+    }
+}

--- a/poporazzi/Domain/Interface/StoreKitServiceInterface.swift
+++ b/poporazzi/Domain/Interface/StoreKitServiceInterface.swift
@@ -1,0 +1,14 @@
+//
+//  StoreKitServiceInterface.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/12/25.
+//
+
+import Foundation
+
+protocol StoreKitServiceInterface {
+    
+    /// 사용자에게 AppStore 리뷰 Alert를 출력합니다.
+    func requestReview()
+}

--- a/poporazzi/Feature/6.FinishConfirmModal/FinishConfirmModalViewModel.swift
+++ b/poporazzi/Feature/6.FinishConfirmModal/FinishConfirmModalViewModel.swift
@@ -13,6 +13,7 @@ final class FinishConfirmModalViewModel: ViewModel {
     
     @Dependency(\.liveActivityService) private var liveActivityService
     @Dependency(\.photoKitService) private var photoKitService
+    @Dependency(\.storeKitService) private var storeKitService
     
     private let disposeBag = DisposeBag()
     private let output: Output
@@ -110,9 +111,11 @@ extension FinishConfirmModalViewModel {
                 case .linkToPhotoAlbum:
                     DeepLinkManager.openPhotoAlbum()
                     owner.navigation.accept(.popToRoot)
+                    owner.storeKitService.requestReview()
                     
                 case .popToHome:
                     owner.navigation.accept(.popToRoot)
+                    owner.storeKitService.requestReview()
                 }
             }
             .disposed(by: disposeBag)


### PR DESCRIPTION
close #84

## *⛳️ Work Description*
- AppStore 리뷰 Alert 기능 구현

## *🧐 트러블슈팅*
### 1. StoreKit을 이용한 AppStore Alert 띄우기
StoreKit의 AppStore 열거형에 접근해 `requestReview(in:)` 함수를 호출할 수 있습니다. [공식문서](https://developer.apple.com/documentation/storekit/appstore/requestreview(in:)-1q8qs#parameters)에서 언급하는 것에 따르면 조금 특이하게 동작하게 되는데, 조건은 다음과 같습니다.
- 해당 사용자가 기기에서 앱을 평가하거나 리뷰하지 않은 경우 >> 365일 기간 내에 최대 3회까지 평가와 리뷰 요청 표시.
- 해당 사용자가 기기에서 앱을 평가하거나 리뷰한 경우 >> 앱 버전이 새롭고 이전에 리뷰를 작성한지 365일이 지났을 경우 표시.

**즉, StoreKit 자체 정책에 따라 Alert가 표시되기 때문에 버튼 등을 이용해 직접적으로 리뷰 Alert를 띄우지 말라고 권고하기도 합니다.**

~~~swift
struct StoreKitService: StoreKitServiceInterface {
    
    /// 사용자에게 AppStore 리뷰 Alert를 출력합니다.
    func requestReview() {
        guard let scene = UIApplication.shared.connectedScenes.first(where: {
            $0.activationState == .foregroundActive
        }) as? UIWindowScene else { return }
        
        Task {
            await MainActor.run {
                AppStore.requestReview(in: scene)
            }
        }
    }
}
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|리뷰 Alert|<img width="300" alt="" src="https://github.com/user-attachments/assets/ee55f11c-a37e-4792-97e7-445967b7e0fd">|