### PR TITLE
스크린샷 제외 기능 구현

### DIFF
--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -40,11 +40,12 @@ struct MockPhotoKitService: PhotoKitInterface {
         return .just(array)
     }
     
-    func saveAlbumAsSingle(title: String, excludeAssets: [String]) throws {
+    func saveAlbumAsSingle(title: String, sectionMediaList: SectionMediaList)  -> Observable<Void> {
         print("[하나의 앨범으로 저장 완료] - \(title)")
+        return .just(())
     }
     
-    func saveAlubmByDay(title: String, sectionMediaList: SectionMediaList, excludeAssets: [String]) -> Observable<Void> {
+    func saveAlubmByDay(title: String, sectionMediaList: SectionMediaList) -> Observable<Void> {
         print("[일차별 앨범으로 저장 완료] - \(title)")
         return .just(())
     }

--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -20,13 +20,22 @@ struct MockPhotoKitService: PhotoKitInterface {
     }
     
     func fetchMediasWithNoThumbnail(mediaFetchType: MediaFetchType, date: Date, ascending: Bool) -> [Media] {
-        Array(repeatElement(Media(id: UUID().uuidString, creationDate: .now, mediaType: .photo), count: 30))
+        Array(repeatElement(.init(
+            id: UUID().uuidString,
+            creationDate: .now,
+            mediaType: .photo(isScreenShot: false)
+        ), count: 30))
     }
     
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]> {
         var array = [Media]()
         for _ in 0..<30 {
-            array.append(Media(id: UUID().uuidString, creationDate: .now, mediaType: .photo, thumbnail: UIImage()))
+            array.append(.init(
+                id: UUID().uuidString,
+                creationDate: .now,
+                mediaType: .photo(isScreenShot: false),
+                thumbnail: UIImage()
+            ))
         }
         return .just(array)
     }

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -76,11 +76,12 @@ extension PhotoKitService {
         )
         fetchResult = fetchAssetResult
         
-        fetchResult?.enumerateObjects { asset, _, _ in
+        fetchResult?.enumerateObjects { [weak self] asset, _, _ in
+            guard let self else { return }
             let media = Media(
                 id: asset.localIdentifier,
                 creationDate: asset.creationDate,
-                mediaType: asset.mediaType == .image ? .photo : .video(duration: asset.duration),
+                mediaType: mediaType(from: asset),
                 thumbnail: nil
             )
             newMedias.append(media)
@@ -116,7 +117,7 @@ extension PhotoKitService {
                             return Media(
                                 id: asset.localIdentifier,
                                 creationDate: asset.creationDate,
-                                mediaType: asset.mediaType == .image ? .photo : .video(duration: asset.duration),
+                                mediaType: self.mediaType(from: asset),
                                 thumbnail: image
                             )
                         }
@@ -271,6 +272,13 @@ extension PhotoKitService {
 // MARK: - Helper
 
 extension PhotoKitService {
+    
+    /// 현재 Asset의 MediaType을 반환합니다.
+    private func mediaType(from asset: PHAsset) -> MediaType {
+        asset.mediaType == .image
+        ? .photo(isScreenShot: asset.mediaSubtypes.contains(.photoScreenshot))
+        : .video(duration: asset.duration)
+    }
     
     /// PHFetchResult를 날짜에 맞게 반환합니다.
     private func fetchAssetResult(

--- a/poporazzi/Data/Service/UserDefaultsService.swift
+++ b/poporazzi/Data/Service/UserDefaultsService.swift
@@ -22,6 +22,9 @@ struct UserDefaultsService {
     
     @UserDefault(key: "excludeAssets", defaultValue: [])
     static var excludeAssets: [String]
+    
+    @UserDefault(key: "isContainScreenshot", defaultValue: true)
+    static var isContainScreenshot: Bool
 }
 
 // MARK: - Syntax Sugar

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -28,7 +28,7 @@ struct Media: Hashable, Equatable {
 
 /// 미디어 타입
 enum MediaType: Hashable {
-    case photo
+    case photo(isScreenShot: Bool)
     case video(duration: TimeInterval)
 }
 

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -28,10 +28,10 @@ protocol PhotoKitInterface {
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]>
     
     /// 하나의 앨범으로 만들어 저장합니다.
-    func saveAlbumAsSingle(title: String, excludeAssets: [String]) throws
+    func saveAlbumAsSingle(title: String, sectionMediaList: SectionMediaList) -> Observable<Void>
     
     /// 일차별로 앨범을 나눈 후 폴더를 만들어 저장합니다.
-    func saveAlubmByDay(title: String, sectionMediaList: SectionMediaList, excludeAssets: [String]) -> Observable<Void>
+    func saveAlubmByDay(title: String, sectionMediaList: SectionMediaList) -> Observable<Void>
     
     /// 사진을 삭제 후 결과 이벤트를 반환합니다.
     func deletePhotos(from assetIdentifiers: [String]) -> Observable<Bool>

--- a/poporazzi/Feature/1.TitleInput/TitleInputView.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputView.swift
@@ -32,6 +32,14 @@ final class TitleInputView: CodeBaseUI {
         color: .subLabel
     )
     
+    /// 세부 옵션 라벨
+    let detailOptionLabel = FormLabel(title: "세부 옵션")
+    
+    let keyboardAccessoryView = UIView()
+    
+    /// 앨범에 스크린샷 포함 스위치
+    let containScreenshotSwitch = FormSwitch(title: "앨범에 스크린샷 포함")
+    
     /// 액션 버튼
     let actionButton = TextFieldActionButton(title: "기록 시작하기")
     
@@ -48,7 +56,11 @@ final class TitleInputView: CodeBaseUI {
         super.layoutSubviews()
         containerView.pin.all(pin.safeArea)
         containerView.flex.layout()
-        titleTextField.action(.setupInputAccessoryView(actionButton))
+        
+        keyboardAccessoryView.pin.width(bounds.width).height(120)
+        keyboardAccessoryView.flex.layout()
+        
+        titleTextField.action(.setupInputAccessoryView(keyboardAccessoryView))
     }
 }
 
@@ -87,6 +99,10 @@ extension TitleInputView {
                 }
             }
         
-        actionButton.pin.height(56)
+        keyboardAccessoryView.flex.direction(.column).justifyContent(.end).define { flex in
+            flex.addItem(detailOptionLabel).marginHorizontal(20)
+            flex.addItem(containScreenshotSwitch).marginTop(8).marginHorizontal(20)
+            flex.addItem(actionButton).marginTop(28)
+        }
     }
 }

--- a/poporazzi/Feature/1.TitleInput/TitleInputView.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputView.swift
@@ -32,10 +32,11 @@ final class TitleInputView: CodeBaseUI {
         color: .subLabel
     )
     
+    /// 키보드 전용 뷰
+    let keyboardAccessoryView = UIView()
+    
     /// 세부 옵션 라벨
     let detailOptionLabel = FormLabel(title: "세부 옵션")
-    
-    let keyboardAccessoryView = UIView()
     
     /// 앨범에 스크린샷 포함 스위치
     let containScreenshotSwitch = FormSwitch(title: "앨범에 스크린샷 포함")
@@ -100,9 +101,10 @@ extension TitleInputView {
             }
         
         keyboardAccessoryView.flex.direction(.column).justifyContent(.end).define { flex in
+            flex.grow(1)
             flex.addItem(detailOptionLabel).marginHorizontal(20)
             flex.addItem(containScreenshotSwitch).marginTop(8).marginHorizontal(20)
-            flex.addItem(actionButton).marginTop(28)
+            flex.addItem(actionButton).marginTop(24)
         }
     }
 }

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
@@ -42,6 +42,7 @@ extension TitleInputViewController {
     func bind() {
         let input = TitleInputViewModel.Input(
             titleTextChanged: scene.titleTextField.textField.rx.text.orEmpty.asSignal(onErrorJustReturn: ""),
+            containScreenshotChanged: scene.containScreenshotSwitch.controlSwitch.rx.isOn.asSignal(onErrorJustReturn: false),
             startButtonTapped: scene.actionButton.button.rx.tap.asSignal()
         )
         let output = viewModel.transform(input)
@@ -63,7 +64,13 @@ extension TitleInputViewController {
             .bind(with: self) { owner, path in
                 switch path {
                 case .pushRecord:
-                    owner.scene.titleTextField.textField.text = ""
+                    Task {
+                        try await Task.sleep(for: .seconds(1))
+                        await MainActor.run {
+                            owner.scene.titleTextField.textField.text = ""
+                            owner.scene.containScreenshotSwitch.controlSwitch.isOn = false
+                        }
+                    }
                 }
             }
             .disposed(by: disposeBag)

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewController.swift
@@ -30,11 +30,6 @@ final class TitleInputViewController: ViewController {
         bind()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        scene.titleTextField.action(.presentKeyboard)
-    }
-    
     deinit {
         Log.print(#file, .deinit)
     }

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
@@ -34,12 +34,14 @@ extension TitleInputViewModel {
     
     struct Input {
         let titleTextChanged: Signal<String>
+        let containScreenshotChanged: Signal<Bool>
         let startButtonTapped: Signal<Void>
     }
     
     struct Output {
         let titleText = BehaviorRelay<String>(value: "")
         let isStartButtonEnabled = BehaviorRelay<Bool>(value: false)
+        let isContainScreenshot = BehaviorRelay<Bool>(value: false)
         let alertPresented = PublishRelay<AlertModel>()
     }
     
@@ -66,6 +68,10 @@ extension TitleInputViewModel {
             .emit(to: output.isStartButtonEnabled)
             .disposed(by: disposeBag)
         
+        input.containScreenshotChanged
+            .emit(to: output.isContainScreenshot)
+            .disposed(by: disposeBag)
+        
         input.startButtonTapped
             .emit(with: self) { owner, _ in
                 let album = Album(title: owner.output.titleText.value, trackingStartDate: .now)
@@ -74,6 +80,7 @@ extension TitleInputViewModel {
                 HapticManager.notification(type: .success)
                 UserDefaultsService.album = album
                 UserDefaultsService.isTracking = true
+                UserDefaultsService.isContainScreenshot = owner.output.isContainScreenshot.value
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
+++ b/poporazzi/Feature/1.TitleInput/TitleInputViewModel.swift
@@ -46,7 +46,7 @@ extension TitleInputViewModel {
     }
     
     enum Navigation {
-        case pushRecord(Album)
+        case pushRecord(Album, Bool)
     }
     
     enum Alert {
@@ -75,7 +75,9 @@ extension TitleInputViewModel {
         input.startButtonTapped
             .emit(with: self) { owner, _ in
                 let album = Album(title: owner.output.titleText.value, trackingStartDate: .now)
-                owner.navigation.accept(.pushRecord(album))
+                let isContainScreenshot = owner.output.isContainScreenshot.value
+                owner.navigation.accept(.pushRecord(album, isContainScreenshot))
+                owner.output.isContainScreenshot.accept(false)
                 owner.liveActivityService.start(to: album)
                 HapticManager.notification(type: .success)
                 UserDefaultsService.album = album

--- a/poporazzi/Feature/3.AlbumEdit/AlbumEditView.swift
+++ b/poporazzi/Feature/3.AlbumEdit/AlbumEditView.swift
@@ -46,6 +46,12 @@ final class AlbumEditView: CodeBaseUI {
     /// 시작날짜 피커
     let startDatePicker = FormDatePicker()
     
+    /// 세부 옵션 라벨
+    let detailOptionLabel = FormLabel(title: "세부 옵션")
+    
+    /// 앨범에 스크린샷 포함 스위치
+    let containScreenshotSwitch = FormSwitch(title: "앨범에 스크린샷 포함")
+    
     init() {
         super.init(frame: .zero)
         setup()
@@ -71,7 +77,7 @@ extension AlbumEditView {
         containerView.flex.direction(.column).define { flex in
             flex.addItem(navigationBar)
             
-            flex.addItem().direction(.column).paddingHorizontal(20).define { flex in
+            flex.addItem().paddingHorizontal(20).define { flex in
                 flex.addItem().marginTop(24).define { flex in
                     flex.addItem(titleFormLabel)
                     flex.addItem(titleTextField).marginTop(12)
@@ -80,6 +86,11 @@ extension AlbumEditView {
                 flex.addItem().marginTop(32).define { flex in
                     flex.addItem(startDateFormLabel)
                     flex.addItem(startDatePicker).marginTop(12)
+                }
+                
+                flex.addItem().marginTop(40).define { flex in
+                    flex.addItem(detailOptionLabel)
+                    flex.addItem(containScreenshotSwitch).marginTop(8)
                 }
             }
         }

--- a/poporazzi/Feature/3.AlbumEdit/AlbumEditViewController.swift
+++ b/poporazzi/Feature/3.AlbumEdit/AlbumEditViewController.swift
@@ -44,6 +44,7 @@ extension AlbumEditViewController {
             viewDidLoad: .just(()),
             titleTextChanged: scene.titleTextField.textField.rx.text.orEmpty.asSignal(onErrorJustReturn: ""),
             startDatePickerTapped: scene.startDatePicker.tapGesture.rx.event.asVoidSignal(),
+            containScreenshotSwitchChanged: scene.containScreenshotSwitch.controlSwitch.rx.isOn.asSignal(onErrorJustReturn: false),
             backButtonTapped: scene.backButton.button.rx.tap.asSignal(),
             saveButtonTapped: scene.saveButton.button.rx.tap.asSignal()
         )
@@ -60,6 +61,12 @@ extension AlbumEditViewController {
         output.startDate
             .bind(with: self) { owner, date in
                 owner.scene.startDatePicker.action(.updateDate(date))
+            }
+            .disposed(by: disposeBag)
+        
+        output.isContainScreenshot
+            .bind(with: self) { owner, isOn in
+                owner.scene.containScreenshotSwitch.controlSwitch.setOn(isOn, animated: false)
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/6.FinishConfirmModal/FinishConfirmModalViewModel.swift
+++ b/poporazzi/Feature/6.FinishConfirmModal/FinishConfirmModalViewModel.swift
@@ -86,9 +86,12 @@ extension FinishConfirmModalViewModel {
                 switch owner.output.saveOption.value {
                 case .saveAsSingle:
                     owner.output.toggleLoading.accept(true)
-                    try? owner.saveAlbumAsSingle()
-                    owner.output.toggleLoading.accept(false)
-                    owner.finishRecord()
+                    owner.saveAlbumAsSingle()
+                        .bind { _ in
+                            owner.output.toggleLoading.accept(false)
+                            owner.finishRecord()
+                        }
+                        .disposed(by: owner.disposeBag)
                     
                 case .saveByDay:
                     owner.output.toggleLoading.accept(true)
@@ -150,10 +153,10 @@ extension FinishConfirmModalViewModel {
 extension FinishConfirmModalViewModel {
     
     /// 하나로 앨범을 저장합니다.
-    private func saveAlbumAsSingle() throws {
-        try photoKitService.saveAlbumAsSingle(
+    private func saveAlbumAsSingle() -> Observable<Void> {
+        photoKitService.saveAlbumAsSingle(
             title: output.album.value.title,
-            excludeAssets: UserDefaultsService.excludeAssets
+            sectionMediaList: output.sectionMediaList.value
         )
     }
     
@@ -161,8 +164,7 @@ extension FinishConfirmModalViewModel {
     private func saveAlubmByDay() -> Observable<Void> {
         photoKitService.saveAlubmByDay(
             title: output.album.value.title,
-            sectionMediaList: output.sectionMediaList.value,
-            excludeAssets: UserDefaultsService.excludeAssets
+            sectionMediaList: output.sectionMediaList.value
         )
     }
 }

--- a/poporazzi/Feature/6.FinishConfirmModal/FinishConfirmModalViewModel.swift
+++ b/poporazzi/Feature/6.FinishConfirmModal/FinishConfirmModalViewModel.swift
@@ -101,6 +101,7 @@ extension FinishConfirmModalViewModel {
                     
                 case .noSave:
                     owner.navigation.accept(.popToRoot)
+                    owner.finishRecord()
                 }
             }
             .disposed(by: disposeBag)

--- a/poporazzi/UIComponent/FormLabel.swift
+++ b/poporazzi/UIComponent/FormLabel.swift
@@ -26,7 +26,7 @@ final class FormLabel: CodeBaseUI {
     init(title: String) {
         super.init(frame: .zero)
         label.text = title
-        setup()
+        setup(color: .clear)
     }
     
     required init?(coder: NSCoder) {

--- a/poporazzi/UIComponent/FormSwitch.swift
+++ b/poporazzi/UIComponent/FormSwitch.swift
@@ -1,31 +1,29 @@
 //
-//  FormLabel.swift
+//  FormSwitch.swift
 //  poporazzi
 //
-//  Created by 김민준 on 4/17/25.
+//  Created by 김민준 on 5/12/25.
 //
 
 import UIKit
 import PinLayout
 import FlexLayout
 
-final class FormLabel: CodeBaseUI {
+final class FormSwitch: CodeBaseUI {
     
     var containerView = UIView()
     
-    let tapGesture = UITapGestureRecognizer()
+    private let formLabel = UILabel("", size: 16, color: .mainLabel)
     
-    /// 앨범 제목 라벨
-    private let label: UILabel = {
-        let label = UILabel()
-        label.font = .setDovemayo(16)
-        label.textColor = .subLabel
-        return label
+    let controlSwitch: UISwitch = {
+        let control = UISwitch()
+        control.onTintColor = .brandPrimary
+        return control
     }()
     
     init(title: String) {
         super.init(frame: .zero)
-        label.text = title
+        formLabel.text = title
         setup()
     }
     
@@ -42,11 +40,13 @@ final class FormLabel: CodeBaseUI {
 
 // MARK: - Layout
 
-extension FormLabel {
+extension FormSwitch {
     
     func configLayout() {
-        containerView.flex.define { flex in
-            flex.addItem(label)
+        containerView.flex.direction(.row).define { flex in
+            flex.addItem(formLabel)
+            flex.addItem().grow(1)
+            flex.addItem(controlSwitch)
         }
     }
 }

--- a/poporazzi/UIComponent/FormSwitch.swift
+++ b/poporazzi/UIComponent/FormSwitch.swift
@@ -24,7 +24,7 @@ final class FormSwitch: CodeBaseUI {
     init(title: String) {
         super.init(frame: .zero)
         formLabel.text = title
-        setup()
+        setup(color: .clear)
     }
     
     required init?(coder: NSCoder) {

--- a/poporazzi/UIComponent/LineTextField.swift
+++ b/poporazzi/UIComponent/LineTextField.swift
@@ -66,6 +66,7 @@ extension LineTextField {
         switch action {
         case let .setupInputAccessoryView(view):
             textField.inputAccessoryView = view
+            textField.becomeFirstResponder()
             
         case .presentKeyboard:
             textField.becomeFirstResponder()


### PR DESCRIPTION
close #88

## *⛳️ Work Description*
- 스크린샷 제외 Switch 화면 별 추가
- 스크린샷 제외 앨범 저장 기능 구현

## *🧐 트러블슈팅*
### 1. PHAsset으로 스크린샷인지 판별하기
~~~swift
/// 현재 Asset의 MediaType을 반환합니다.
private func mediaType(from asset: PHAsset) -> MediaType {
    asset.mediaType == .image
    ? .photo(isScreenShot: asset.mediaSubtypes.contains(.photoScreenshot)) // ⭐️ PHMediaSubTypes의 contains에 접근해 판별 가능
    : .video(duration: asset.duration)
}
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|앨범 제목 입력|<img width="300" alt="" src="https://github.com/user-attachments/assets/78513a34-1f02-42d1-97fb-b7bc1a725140">|
|앨범 수정|<img width="300" alt="" src="https://github.com/user-attachments/assets/61191d36-cab6-4b0b-9dc9-b7c8443153f1">|