### PR TITLE
미디어 유형 및 필터링 옵션 추가에 따른 기능 구현

### DIFF
--- a/poporazzi.xcodeproj/project.pbxproj
+++ b/poporazzi.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 				Data/Service/LiveActivityService.swift,
 				Domain/Entity/Album.swift,
 				Domain/Entity/Media.swift,
+				Domain/Entity/MediaFetchOption.swift,
+				Domain/Entity/MediaFilterOption.swift,
 				Domain/Interface/LiveActivityInterface.swift,
 				Resource/Colors.xcassets,
 				Resource/Font/DovemayoGothic/Dovemayo_gothic.ttf,

--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -27,6 +27,10 @@ struct MockPhotoKitService: PhotoKitInterface {
         ), count: 30))
     }
     
+    func fetchMediaListWithNoThumbnail(from album: Album) -> [Media] {
+        []
+    }
+    
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]> {
         var array = [Media]()
         for _ in 0..<30 {

--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -19,16 +19,12 @@ struct MockPhotoKitService: PhotoKitInterface {
         print("[권한 허용 완료]")
     }
     
-    func fetchMediasWithNoThumbnail(mediaFetchType: MediaFetchOption, date: Date, ascending: Bool) -> [Media] {
+    func fetchMediaListWithNoThumbnail(from album: Album) -> [Media] {
         Array(repeatElement(.init(
             id: UUID().uuidString,
             creationDate: .now,
-            mediaType: .photo(isScreenShot: false)
+            mediaType: .photo(.selfShooting, .heic)
         ), count: 30))
-    }
-    
-    func fetchMediaListWithNoThumbnail(from album: Album) -> [Media] {
-        []
     }
     
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]> {
@@ -37,7 +33,7 @@ struct MockPhotoKitService: PhotoKitInterface {
             array.append(.init(
                 id: UUID().uuidString,
                 creationDate: .now,
-                mediaType: .photo(isScreenShot: false),
+                mediaType: .photo(.selfShooting, .heic),
                 thumbnail: UIImage()
             ))
         }

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -311,8 +311,7 @@ extension PhotoKitService {
     
     /// 현재 Asset의 MediaType을 반환합니다.
     private func mediaType(from asset: PHAsset) -> Media.MediaType {
-        let resources = PHAssetResource.assetResources(for: asset)
-        let uniformTypeIdentifier = resources.first?.uniformTypeIdentifier ?? ""
+        let uniformTypeIdentifier = asset.value(forKey: "uniformTypeIdentifier") as? String ?? ""
         let format = String(uniformTypeIdentifier.split(separator: ".").last ?? "")
         
         switch asset.mediaType {

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -310,15 +310,14 @@ extension PhotoKitService {
 extension PhotoKitService {
     
     /// 현재 Asset의 MediaType을 반환합니다.
-    private func mediaType(from asset: PHAsset) -> MediaType {
+    private func mediaType(from asset: PHAsset) -> Media.MediaType {
         let resources = PHAssetResource.assetResources(for: asset)
         let uniformTypeIdentifier = resources.first?.uniformTypeIdentifier ?? ""
         let format = String(uniformTypeIdentifier.split(separator: ".").last ?? "")
-        print(format)
         
         switch asset.mediaType {
         case .image:
-            let photoFormat = PhotoFormat(rawValue: format) ?? .heic
+            let photoFormat = Media.MediaType.PhotoFormat(rawValue: format) ?? .heic
             
             if asset.mediaSubtypes.contains(.photoScreenshot) {
                 return.photo(.screenshot, photoFormat)
@@ -331,7 +330,7 @@ extension PhotoKitService {
             }
             
         case .video:
-            let videoFormat = VideoFormat(rawValue: format) ?? .quickTimeMovie
+            let videoFormat = Media.MediaType.VideoFormat(rawValue: format) ?? .quickTimeMovie
             
             if videoFormat == .quickTimeMovie {
                 return .video(.selfShooting, videoFormat, duration: asset.duration)

--- a/poporazzi/Domain/Entity/Album.swift
+++ b/poporazzi/Domain/Entity/Album.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// 앨범
 struct Album {
     
     /// 고유 아이디
@@ -51,28 +52,6 @@ struct Album {
             mediaFetchOption: .all,
             mediaFilterOption: .init()
         )
-    }
-}
-
-struct MediaFilterOption {
-    
-    /// 직접 촬영한 사진 포함 여부
-    var isContainSelfShooting: Bool
-    
-    /// 다운로드 사진 포함 여부
-    var isContainDownload: Bool
-    
-    /// 스크린샷 포함 여부
-    var isContainScreenshot: Bool
-    
-    init(
-        isContainSelfShooting: Bool = true,
-        isContainDownload: Bool = false,
-        isContainScreenshot: Bool = false
-    ) {
-        self.isContainSelfShooting = isContainSelfShooting
-        self.isContainDownload = isContainDownload
-        self.isContainScreenshot = isContainScreenshot
     }
 }
 

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -28,8 +28,30 @@ struct Media: Hashable, Equatable {
 
 /// 미디어 타입
 enum MediaType: Hashable {
-    case photo(isScreenShot: Bool)
-    case video(duration: TimeInterval)
+    case photo(PhotoType, PhotoFormat)
+    case video(VideoType, VideoFormat, duration: TimeInterval)
+}
+
+enum PhotoType {
+    case selfShooting
+    case download
+    case screenshot
+}
+
+enum PhotoFormat: String {
+    case heic
+    case png
+    case jpeg
+}
+
+enum VideoType {
+    case selfShooting
+    case download
+}
+
+enum VideoFormat: String {
+    case quickTimeMovie = "quicktime-movie"
+    case mpeg4 = "mpeg-4"
 }
 
 /// 미디어 검색 타입

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -10,9 +10,18 @@ import UIKit
 /// 미디어
 struct Media: Hashable, Equatable {
     
+    /// 고유 ID
+    ///
+    /// - Asset의 ID 저장
     let id: String
+    
+    /// 생성일
     let creationDate: Date?
+    
+    /// 미디어 타입
     let mediaType: MediaType
+    
+    /// 썸네일
     var thumbnail: UIImage?
     
     func hash(into hasher: inout Hasher) {
@@ -24,41 +33,42 @@ struct Media: Hashable, Equatable {
         && lhs.mediaType == rhs.mediaType
         && lhs.thumbnail != rhs.thumbnail
     }
-}
-
-/// 미디어 타입
-enum MediaType: Hashable {
-    case photo(PhotoType, PhotoFormat)
-    case video(VideoType, VideoFormat, duration: TimeInterval)
-}
-
-enum PhotoType {
-    case selfShooting
-    case download
-    case screenshot
-}
-
-enum PhotoFormat: String {
-    case heic
-    case png
-    case jpeg
-}
-
-enum VideoType {
-    case selfShooting
-    case download
-}
-
-enum VideoFormat: String {
-    case quickTimeMovie = "quicktime-movie"
-    case mpeg4 = "mpeg-4"
-}
-
-/// 미디어 검색 타입
-enum MediaFetchOption {
-    case all
-    case photo
-    case video
+    
+    /// 미디어 타입
+    enum MediaType: Hashable {
+        
+        /// 사진
+        case photo(PhotoType, PhotoFormat)
+        
+        /// 비디오
+        case video(VideoType, VideoFormat, duration: TimeInterval)
+        
+        /// 사진 타입
+        enum PhotoType {
+            case selfShooting
+            case download
+            case screenshot
+        }
+        
+        /// 사진 확장자
+        enum PhotoFormat: String {
+            case heic
+            case png
+            case jpeg
+        }
+        
+        /// 비디오 타입
+        enum VideoType {
+            case selfShooting
+            case download
+        }
+        
+        /// 비디오 확장자
+        enum VideoFormat: String {
+            case quickTimeMovie = "quicktime-movie"
+            case mpeg4 = "mpeg-4"
+        }
+    }
 }
 
 // MARK: - Helper

--- a/poporazzi/Domain/Entity/MediaFetchOption.swift
+++ b/poporazzi/Domain/Entity/MediaFetchOption.swift
@@ -1,0 +1,21 @@
+//
+//  MediaFetchOption.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/15/25.
+//
+
+import Foundation
+
+/// 미디어 검색 타입
+enum MediaFetchOption {
+    
+    /// 전체 검색
+    case all
+    
+    /// 사진 검색
+    case photo
+    
+    /// 비디오 검색
+    case video
+}

--- a/poporazzi/Domain/Entity/MediaFilterOption.swift
+++ b/poporazzi/Domain/Entity/MediaFilterOption.swift
@@ -1,0 +1,31 @@
+//
+//  MediaFilterOption.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/15/25.
+//
+
+import Foundation
+
+/// 미디어 필터링 옵션
+struct MediaFilterOption {
+    
+    /// 직접 촬영한 사진 포함 여부
+    var isContainSelfShooting: Bool
+    
+    /// 다운로드 사진 포함 여부
+    var isContainDownload: Bool
+    
+    /// 스크린샷 포함 여부
+    var isContainScreenshot: Bool
+    
+    init(
+        isContainSelfShooting: Bool = true,
+        isContainDownload: Bool = false,
+        isContainScreenshot: Bool = false
+    ) {
+        self.isContainSelfShooting = isContainSelfShooting
+        self.isContainDownload = isContainDownload
+        self.isContainScreenshot = isContainScreenshot
+    }
+}

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -24,6 +24,8 @@ protocol PhotoKitInterface {
         ascending: Bool
     ) -> [Media]
     
+    func fetchMediaListWithNoThumbnail(from album: Album) -> [Media]
+    
     /// Media 배열 이벤트를 반환합니다.
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]>
     

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -18,12 +18,6 @@ protocol PhotoKitInterface {
     func requestAuth()
     
     /// Thumbnail 없이 Media 배열을 반환합니다.
-    func fetchMediasWithNoThumbnail(
-        mediaFetchType: MediaFetchOption,
-        date: Date,
-        ascending: Bool
-    ) -> [Media]
-    
     func fetchMediaListWithNoThumbnail(from album: Album) -> [Media]
     
     /// Media 배열 이벤트를 반환합니다.

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by 김민준 on 4/5/25.
 //
 
-import UIKit
 import Foundation
 import RxSwift
 import RxCocoa
@@ -126,13 +125,15 @@ extension RecordViewModel {
     
     func transform(_ input: Input) -> Output {
         
+        input.viewDidLoad
+            .emit(with: self) { owner, _ in
+                owner.output.setupSeeMoreMenu.accept(self.seemoreMenu)
+            }
+            .disposed(by: disposeBag)
+        
         // 1. 화면 진입 시 기본 이미지 로드
         input.viewDidLoad
             .asObservable()
-            .do { [weak self] _ in
-                guard let self else { return }
-                self.output.setupSeeMoreMenu.accept(self.seemoreMenu)
-            }
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self) { owner, _ in
                 owner.output.mediaList.accept(owner.fetchAllMediaListWithNoThumbnail())
@@ -403,21 +404,23 @@ extension RecordViewModel {
     /// - 제외된 사진을 필터링합니다.
     /// - 스크린샷이 제외되었을 때 필터링합니다.
     private func fetchAllMediaListWithNoThumbnail() -> [Media] {
-        let trackingStartDate = output.album.value.startDate
-        return photoKitService.fetchMediasWithNoThumbnail(
-            mediaFetchType: .all,
-            date: trackingStartDate,
-            ascending: true
-        )
-        .filter { !Set(output.album.value.excludeMediaList).contains($0.id) }
-        .filter {
-            if !output.album.value.mediaFilterOption.isContainScreenshot {
-                if case let .photo(isScreenshot) = $0.mediaType {
-                    return !isScreenshot
-                }
-            }
-            return true
-        }
+        let album = output.album.value
+        return photoKitService.fetchMediaListWithNoThumbnail(from: album)
+        
+//        return photoKitService.fetchMediasWithNoThumbnail(
+//            mediaFetchType: .all,
+//            date: trackingStartDate,
+//            ascending: true
+//        )
+//        .filter { !Set(output.album.value.excludeMediaList).contains($0.id) }
+//        .filter {
+//            if !output.album.value.mediaFilterOption.isContainScreenshot {
+//                if case let .photo(isScreenshot) = $0.mediaType {
+//                    return !isScreenshot
+//                }
+//            }
+//            return true
+//        }
     }
     
     /// 전체 Media 리스트를 반환합니다.

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -406,21 +406,7 @@ extension RecordViewModel {
     private func fetchAllMediaListWithNoThumbnail() -> [Media] {
         let album = output.album.value
         return photoKitService.fetchMediaListWithNoThumbnail(from: album)
-        
-//        return photoKitService.fetchMediasWithNoThumbnail(
-//            mediaFetchType: .all,
-//            date: trackingStartDate,
-//            ascending: true
-//        )
-//        .filter { !Set(output.album.value.excludeMediaList).contains($0.id) }
-//        .filter {
-//            if !output.album.value.mediaFilterOption.isContainScreenshot {
-//                if case let .photo(isScreenshot) = $0.mediaType {
-//                    return !isScreenshot
-//                }
-//            }
-//            return true
-//        }
+            .filter { !Set(output.album.value.excludeMediaList).contains($0.id) }
     }
     
     /// 전체 Media 리스트를 반환합니다.

--- a/poporazzi/UIComponent/RecordCell.swift
+++ b/poporazzi/UIComponent/RecordCell.swift
@@ -113,7 +113,7 @@ extension RecordCell {
     
     enum Action {
         case setImage(UIImage?)
-        case setMediaType(MediaType)
+        case setMediaType(Media.MediaType)
     }
     
     func action(_ action: Action) {

--- a/poporazzi/UIComponent/RecordCell.swift
+++ b/poporazzi/UIComponent/RecordCell.swift
@@ -132,7 +132,7 @@ extension RecordCell {
                 videoOverlay.isHidden = true
                 videoDurationLabel.flex.markDirty()
                 
-            case let .video(duration):
+            case let .video(_, _, duration):
                 videoDurationLabel.text = duration.videoDurationFormat
                 videoOverlay.isHidden = false
                 videoDurationLabel.flex.markDirty()


### PR DESCRIPTION
close #96

## *⛳️ Work Description*
- 직접 촬영한 사진 / 다운로드한 사진 / 스크린샷 필터링 기능 구현

## *🧐 트러블슈팅*
### 1. 직접 촬영한 사진 / 다운로드한 사진 / 스크린샷 구별하기
위의 3가지 사용자가 설정할 옵션에 따라 사진이 필터링되는 기능을 구현하기 위한 방법은, 결론부터 이야기하자면 100%가 아닙니다.  스크린샷의 경우 PHAsset을 활용해 `asset.mediaSubtypes.contains(.photoScreenshot)`로 공식적으로 구할 수 있지만, 나머지는 아니기 때문입니다.

이를 구현하기 위한 대안으로 선택한 로직은
1. 사진의 경우 확장자가 HEIC이면 직접 촬영한 사진, 나머지 확장자(PNG, JPEG 등)는 다운로드한 사진으로 구분
2. 동영상의 경우 확장자가 MOV면 직접 촬영한 영상, 나머지 확장자(MPEG4 등)는 다운로드한 영상으로 구분

만약 사용자가 카메라 설정에서 '고효율' 옵션이 아닌, '높은 호환성' 모드 선택 시 다운로드한 사진으로 인식할 수 있기 때문에(HEIC, MOV로 저장되지 않음), 자칫 잘못하면 잘못된 데이터를 사용자에게 제공할 수 있습니다. 이는 직접 촬영한 영상을 적은 비용으로 필터링할 수 있다는 비즈니스적 장점이 더 크다고 판단해, 사용자에게 저장 기준을 고지함으로써 해결하려 합니다.

++ 더 정확한 방법으로는, Image를 반환 받으며 메타데이터 내 카메라 정보의 유무에 따라 구분할 수 있지만 이는 비동기적으로 시간이 오래걸리기 때문에 전체 사진 개수를 빠르게 사용자에게 제공하기 어려워짐. 추후 업데이트 필요시 해당 방법으로 전환 예정.

<img width="300" alt="" src="https://github.com/user-attachments/assets/1af9ed4a-d39e-40b9-b3ca-de7151a844a1">

~~~swift
/// 썸네일 없이 기록을 반환합니다.
func fetchMediaListWithNoThumbnail(from album: Album) -> [Media] {
    let fetchResult = fetchAssetResult(from: album)
    self.fetchResultForObserve = fetchResult
    
    var mediaList = [Media]()
    fetchResult.enumerateObjects { [weak self] asset, _, _ in
        guard let self else { return }
        let mediaType = self.mediaType(from: asset)
        let option = album.mediaFilterOption
        
        switch mediaType {
        case let .photo(type, _):
            let isContain = option.isContainSelfShooting && type == .selfShooting
            || option.isContainDownload && type == .download
            || option.isContainScreenshot && type == .screenshot
            
            if isContain {
                let media = Media(
                    id: asset.localIdentifier,
                    creationDate: asset.creationDate,
                    mediaType: mediaType,
                    thumbnail: nil
                )
                mediaList.append(media)
            }
            
        case let .video(type, _, _):
            let isContain = option.isContainSelfShooting && type == .selfShooting
            || option.isContainDownload && type == .download
            
            if isContain {
                let media = Media(
                    id: asset.localIdentifier,
                    creationDate: asset.creationDate,
                    mediaType: mediaType,
                    thumbnail: nil
                )
                mediaList.append(media)
            }
        }
    }
    
    return mediaList
}
~~~
~~~swift
/// 현재 Asset의 MediaType을 반환합니다.
private func mediaType(from asset: PHAsset) -> Media.MediaType {
    let uniformTypeIdentifier = asset.value(forKey: "uniformTypeIdentifier") as? String ?? ""
    let format = String(uniformTypeIdentifier.split(separator: ".").last ?? "")
    
    switch asset.mediaType {
    case .image:
        let photoFormat = Media.MediaType.PhotoFormat(rawValue: format) ?? .heic
        
        if asset.mediaSubtypes.contains(.photoScreenshot) {
            return.photo(.screenshot, photoFormat)
        }
        
        if photoFormat == .heic {
            return .photo(.selfShooting, photoFormat)
        } else {
            return .photo(.download, photoFormat)
        }
        
    case .video:
        let videoFormat = Media.MediaType.VideoFormat(rawValue: format) ?? .quickTimeMovie
        
        if videoFormat == .quickTimeMovie {
            return .video(.selfShooting, videoFormat, duration: asset.duration)
        } else {
            return .video(.download, videoFormat, duration: asset.duration)
        }
        
    default:
        return .photo(.selfShooting, .heic)
    }
}
~~~