### PR TITLE
앨범 시작 및 종료 시간 선택 기능 업데이트

### DIFF
--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -184,8 +184,8 @@ extension Coordinator {
     private func presentDatePickerModal(_ editVC: AlbumEditViewController?, _ editVM: AlbumEditViewModel, startDate: Date) {
         let datePickerVM = DatePickerModalViewModel(output: .init(selectedDate: .init(value: startDate)))
         let datePickerVC = DatePickerModalViewController(viewModel: datePickerVM)
-        datePickerVC.sheetPresentationController?.preferredCornerRadius = 20
-        datePickerVC.sheetPresentationController?.detents = [.custom(resolver: { _ in 300 })]
+        datePickerVC.sheetPresentationController?.preferredCornerRadius = 40
+        datePickerVC.sheetPresentationController?.detents = [.custom(resolver: { _ in 480 })]
         datePickerVC.sheetPresentationController?.prefersGrabberVisible = true
         editVC?.present(datePickerVC, animated: true)
         

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -134,6 +134,7 @@ extension Coordinator {
                 album: .init(value: album),
                 titleText: .init(value: album.title),
                 startDate: .init(value: album.startDate),
+                endDate: .init(value: nil), // TODO: 고치기
                 mediaFetchOption: .init(value: album.mediaFetchOption),
                 mediaFilterOption: .init(value: album.mediaFilterOption)
             )
@@ -144,8 +145,11 @@ extension Coordinator {
         editVM.navigation
             .bind(with: self) { [weak editVC] owner, path in
                 switch path {
-                case .presentStartDatePicker(let date):
-                    owner.presentDatePickerModal(editVC, editVM, startDate: date)
+                case let .presentStartDatePicker(startDate, endDate):
+                    owner.presentDatePickerModal(editVC, editVM, .startDate, startDate, endDate)
+                    
+                case let .presentEndDatePicker(startDate, endDate):
+                    owner.presentDatePickerModal(editVC, editVM, .endDate, startDate, endDate)
                     
                 case .pop:
                     owner.navigationController.popViewController(animated: true)
@@ -181,19 +185,37 @@ extension Coordinator {
 extension Coordinator {
     
     /// 날짜 선택 모달을 Present 합니다.
-    private func presentDatePickerModal(_ editVC: AlbumEditViewController?, _ editVM: AlbumEditViewModel, startDate: Date) {
-        let datePickerVM = DatePickerModalViewModel(output: .init(selectedDate: .init(value: startDate)))
-        let datePickerVC = DatePickerModalViewController(viewModel: datePickerVM)
+    private func presentDatePickerModal(
+        _ editVC: AlbumEditViewController?,
+        _ editVM: AlbumEditViewModel,
+        _ modalState: DatePickerModalViewModel.ModalState,
+        _ startDate: Date,
+        _ endDate: Date?
+    ) {
+        let datePickerVM = DatePickerModalViewModel(
+            output: .init(
+                modalState: .init(value: modalState),
+                startDate: .init(value: startDate),
+                endDate: .init(value: endDate)
+            )
+        )
+        let datePickerVC = DatePickerModalViewController(
+            viewModel: datePickerVM,
+            variation: modalState == .startDate ? .startDate : .endDate
+        )
         datePickerVC.sheetPresentationController?.preferredCornerRadius = 40
-        datePickerVC.sheetPresentationController?.detents = [.custom(resolver: { _ in 480 })]
         datePickerVC.sheetPresentationController?.prefersGrabberVisible = true
         editVC?.present(datePickerVC, animated: true)
         
         datePickerVM.navigation
             .bind(with: self) { owner, path in
                 switch path {
-                case let .pop(date):
+                case let .popFromStartDate(date):
                     editVM.delegate.accept(.startDateDidChanged(date))
+                    editVC?.dismiss(animated: true)
+                    
+                case let .popFromEndDate(date):
+                    editVM.delegate.accept(.endDateDidChanged(date))
                     editVC?.dismiss(animated: true)
                 }
             }

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -134,7 +134,7 @@ extension Coordinator {
                 album: .init(value: album),
                 titleText: .init(value: album.title),
                 startDate: .init(value: album.startDate),
-                endDate: .init(value: nil), // TODO: 고치기
+                endDate: .init(value: album.endDate),
                 mediaFetchOption: .init(value: album.mediaFetchOption),
                 mediaFilterOption: .init(value: album.mediaFilterOption)
             )
@@ -192,11 +192,19 @@ extension Coordinator {
         _ startDate: Date,
         _ endDate: Date?
     ) {
+        let isEndofRecordActive: Bool = {
+            switch modalState {
+            case .startDate: return false
+            case .endDate: return endDate == nil
+            }
+        }()
+        
         let datePickerVM = DatePickerModalViewModel(
             output: .init(
                 modalState: .init(value: modalState),
                 startDate: .init(value: startDate),
-                endDate: .init(value: endDate)
+                endDate: .init(value: endDate),
+                isEndOfRecordActive: .init(value: isEndofRecordActive)
             )
         )
         let datePickerVC = DatePickerModalViewController(

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -218,6 +218,9 @@ extension Coordinator {
         datePickerVM.navigation
             .bind(with: self) { owner, path in
                 switch path {
+                case .pop:
+                    editVC?.dismiss(animated: true)
+                    
                 case let .popFromStartDate(date):
                     editVM.delegate.accept(.startDateDidChanged(date))
                     editVC?.dismiss(animated: true)

--- a/poporazzi/Data/Service/PersistenceDataService/PersistenceAlbum.swift
+++ b/poporazzi/Data/Service/PersistenceDataService/PersistenceAlbum.swift
@@ -20,6 +20,9 @@ final class PersistenceAlbum: Object {
     /// 시작 날짜
     @Persisted var startDate: Date
     
+    /// 종료 날짜
+    @Persisted var endDate: Date?
+    
     /// 제외된 미디어 리스트
     @Persisted var excludeMediaList: List<String>
     
@@ -33,6 +36,7 @@ final class PersistenceAlbum: Object {
         id: String,
         title: String,
         startDate: Date,
+        endDate: Date?,
         excludeMediaList: List<String>,
         mediaFetchOption: PersistenceMediaFetchOption,
         mediaFilterOption: PersistenceMediaFilterOption?
@@ -41,6 +45,7 @@ final class PersistenceAlbum: Object {
         self.id = id
         self.title = title
         self.startDate = startDate
+        self.endDate = endDate
         self.excludeMediaList = excludeMediaList
         self.mediaFetchOption = mediaFetchOption
         self.mediaFilterOption = mediaFilterOption

--- a/poporazzi/Data/Service/PersistenceDataService/PersistenceService.swift
+++ b/poporazzi/Data/Service/PersistenceDataService/PersistenceService.swift
@@ -10,7 +10,7 @@ import RealmSwift
 
 final class PersistenceService: PersistenceInterface {
     
-    private let realm = try! Realm()
+    private let realm = try? Realm()
 }
 
 // MARK: - Album
@@ -23,13 +23,14 @@ extension PersistenceService {
             id: album.id,
             title: album.title,
             startDate: album.startDate,
+            endDate: album.endDate,
             excludeMediaList: .init(),
             mediaFetchOption: toPersistence(from: album.mediaFetchOption),
             mediaFilterOption: toPersistence(from: album.mediaFilterOption)
         )
         
-        try realm.write {
-            realm.add(album)
+        try realm?.write {
+            realm?.add(album)
         }
     }
     
@@ -46,9 +47,10 @@ extension PersistenceService {
     func updateAlbum(to newAlbum: Album) {
         guard let persistenceAlbum = readPersistenceAlbum(fromId: newAlbum.id) else { return }
         do {
-            try realm.write {
+            try realm?.write {
                 persistenceAlbum.title = newAlbum.title
                 persistenceAlbum.startDate = newAlbum.startDate
+                persistenceAlbum.endDate = newAlbum.endDate
                 persistenceAlbum.mediaFetchOption = toPersistence(from: newAlbum.mediaFetchOption)
                 persistenceAlbum.mediaFilterOption = toPersistence(from: newAlbum.mediaFilterOption)
             }
@@ -66,7 +68,7 @@ extension PersistenceService {
         }
         
         do {
-            try realm.write {
+            try realm?.write {
                 persistenceAlbum.excludeMediaList.removeAll()
                 persistenceAlbum.excludeMediaList.append(objectsIn: Array(album.excludeMediaList))
             }
@@ -81,8 +83,8 @@ extension PersistenceService {
 extension PersistenceService {
     
     private func readPersistenceAlbum(fromId: String) -> PersistenceAlbum? {
-        let albums = realm.objects(PersistenceAlbum.self)
-        return albums.filter({ $0.id == fromId }).first
+        let albums = realm?.objects(PersistenceAlbum.self)
+        return albums?.filter({ $0.id == fromId }).first
     }
 }
 
@@ -111,6 +113,7 @@ extension PersistenceService {
             id: album.id,
             title: album.title,
             startDate: album.startDate,
+            endDate: album.endDate,
             excludeMediaList: Set(album.excludeMediaList),
             mediaFetchOption: toEntity(from: album.mediaFetchOption),
             mediaFilterOption: toEntity(from: album.mediaFilterOption)

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -352,13 +352,11 @@ extension PhotoKitService {
     
     /// 미디어 패치를 위한 Predicate 객체를 생성합니다.
     private func makePredicate(from album: Album) -> NSPredicate {
-        let dateFormat = "creationDate > %@"
-        let mediaFormat = "mediaType == %d"
-        
         var format = ""
         var arguments = [CVarArg]()
         
         // 1. 미디어 유형 설정
+        let mediaFormat = "mediaType == %d"
         switch album.mediaFetchOption {
         case .all:
             format += ("(\(mediaFormat) OR \(mediaFormat))")
@@ -373,8 +371,14 @@ extension PhotoKitService {
         }
         
         // 2. 시작 날짜 설정
-        let result = format + " AND " + dateFormat
+        var result = format + " AND " + "creationDate >= %@"
         arguments.append(album.startDate as NSDate)
+        
+        // 3. 종료 날짜 설정
+        if let endDate = album.endDate {
+            result += " AND " + "creationDate <= %@"
+            arguments.append(endDate as NSDate)
+        }
         
         return .init(format: result, argumentArray: arguments)
     }

--- a/poporazzi/Domain/Entity/Album.swift
+++ b/poporazzi/Domain/Entity/Album.swift
@@ -19,6 +19,9 @@ struct Album {
     /// 시작 날짜
     var startDate: Date
     
+    /// 종료 날짜
+    var endDate: Date?
+    
     /// 제외된 미디어 리스트
     var excludeMediaList: Set<String>
     
@@ -32,6 +35,7 @@ struct Album {
         id: String = UUID().uuidString,
         title: String,
         startDate: Date = .now,
+        endDate: Date? = nil,
         excludeMediaList: Set<String> = [],
         mediaFetchOption: MediaFetchOption,
         mediaFilterOption: MediaFilterOption
@@ -39,6 +43,7 @@ struct Album {
         self.id = id
         self.title = title
         self.startDate = startDate
+        self.endDate = endDate
         self.excludeMediaList = excludeMediaList
         self.mediaFetchOption = mediaFetchOption
         self.mediaFilterOption = mediaFilterOption

--- a/poporazzi/Feature/4.AlbumEdit/AlbumEditView.swift
+++ b/poporazzi/Feature/4.AlbumEdit/AlbumEditView.swift
@@ -44,10 +44,10 @@ final class AlbumEditView: CodeBaseUI {
     let startDatePicker = FormDatePicker()
     
     /// 종료시간 양식 라벨
-    let finishDateFormLabel = FormLabel(title: "종료 시간")
+    let endDateFormLabel = FormLabel(title: "종료 시간")
     
     /// 종료시간 피커
-    let finishDatePicker = FormDatePicker(title: "~ 기록 종료 시 까지")
+    let endDatePicker = FormDatePicker(title: "~ 기록 종료 시 까지")
     
     /// 미디어 유형
     private let saveItemFormLabel = FormLabel(title: "미디어 종류")
@@ -155,8 +155,8 @@ extension AlbumEditView {
                 flex.addItem(startDateFormLabel).marginTop(32)
                 flex.addItem(startDatePicker).marginTop(6)
                 
-                flex.addItem(finishDateFormLabel).marginTop(24)
-                flex.addItem(finishDatePicker).marginTop(6)
+                flex.addItem(endDateFormLabel).marginTop(24)
+                flex.addItem(endDatePicker).marginTop(6)
                 
                 flex.addItem(saveItemFormLabel).marginTop(32)
                 flex.addItem(choiceChipView).marginTop(16)

--- a/poporazzi/Feature/4.AlbumEdit/AlbumEditView.swift
+++ b/poporazzi/Feature/4.AlbumEdit/AlbumEditView.swift
@@ -37,10 +37,10 @@ final class AlbumEditView: CodeBaseUI {
     /// 제목 텍스트필드
     let titleTextField = LineTextField(size: 20, placeholder: "플레이스홀더")
     
-    /// 시작날짜 양식 라벨
-    let startDateFormLabel = FormLabel(title: "시작 날짜")
+    /// 시작시간 양식 라벨
+    let startDateFormLabel = FormLabel(title: "시작 시간")
     
-    /// 시작날짜 피커
+    /// 시작시간 피커
     let startDatePicker = FormDatePicker()
     
     /// 미디어 유형

--- a/poporazzi/Feature/4.AlbumEdit/AlbumEditView.swift
+++ b/poporazzi/Feature/4.AlbumEdit/AlbumEditView.swift
@@ -43,6 +43,12 @@ final class AlbumEditView: CodeBaseUI {
     /// 시작시간 피커
     let startDatePicker = FormDatePicker()
     
+    /// 종료시간 양식 라벨
+    let finishDateFormLabel = FormLabel(title: "종료 시간")
+    
+    /// 종료시간 피커
+    let finishDatePicker = FormDatePicker(title: "~ 기록 종료 시 까지")
+    
     /// 미디어 유형
     private let saveItemFormLabel = FormLabel(title: "미디어 종류")
     
@@ -148,6 +154,9 @@ extension AlbumEditView {
                 
                 flex.addItem(startDateFormLabel).marginTop(32)
                 flex.addItem(startDatePicker).marginTop(6)
+                
+                flex.addItem(finishDateFormLabel).marginTop(24)
+                flex.addItem(finishDatePicker).marginTop(6)
                 
                 flex.addItem(saveItemFormLabel).marginTop(32)
                 flex.addItem(choiceChipView).marginTop(16)

--- a/poporazzi/Feature/4.AlbumEdit/AlbumEditViewController.swift
+++ b/poporazzi/Feature/4.AlbumEdit/AlbumEditViewController.swift
@@ -44,7 +44,7 @@ extension AlbumEditViewController {
             viewDidLoad: .just(()),
             titleTextChanged: scene.titleTextField.textField.rx.text.orEmpty.asSignal(onErrorJustReturn: ""),
             startDatePickerTapped: scene.startDatePicker.tapGesture.rx.event.asVoidSignal(),
-            endDatePickerTapped: scene.finishDatePicker.tapGesture.rx.event.asVoidSignal(),
+            endDatePickerTapped: scene.endDatePicker.tapGesture.rx.event.asVoidSignal(),
             allSaveChoiceChipTapped: scene.allChoiceChip.button.rx.tap.asSignal(),
             photoChoiceChipTapped: scene.photoChoiceChip.button.rx.tap.asSignal(),
             videoChoiceChipTapped: scene.videoChoiceChip.button.rx.tap.asSignal(),
@@ -60,13 +60,22 @@ extension AlbumEditViewController {
             .bind(with: self) { owner, record in
                 owner.scene.titleTextField.action(.updateText(record.title))
                 owner.scene.titleTextField.action(.updatePlaceholder(record.title))
-                owner.scene.startDatePicker.action(.updateDate(record.startDate))
             }
             .disposed(by: disposeBag)
         
         output.startDate
-            .bind(with: self) { owner, date in
-                owner.scene.startDatePicker.action(.updateDate(date))
+            .bind(with: self) { owner, startDate in
+                owner.scene.startDatePicker.action(.updateDateLabel(startDate.startDateFullFormat))
+            }
+            .disposed(by: disposeBag)
+        
+        output.endDate
+            .bind(with: self) { owner, endDate in
+                if let endDate = endDate {
+                    owner.scene.endDatePicker.action(.updateDateLabel(endDate.endDateFullFormat))
+                } else {
+                    owner.scene.endDatePicker.action(.updateDateLabel("기록 종료 시 까지"))
+                }
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/4.AlbumEdit/AlbumEditViewController.swift
+++ b/poporazzi/Feature/4.AlbumEdit/AlbumEditViewController.swift
@@ -44,6 +44,7 @@ extension AlbumEditViewController {
             viewDidLoad: .just(()),
             titleTextChanged: scene.titleTextField.textField.rx.text.orEmpty.asSignal(onErrorJustReturn: ""),
             startDatePickerTapped: scene.startDatePicker.tapGesture.rx.event.asVoidSignal(),
+            endDatePickerTapped: scene.finishDatePicker.tapGesture.rx.event.asVoidSignal(),
             allSaveChoiceChipTapped: scene.allChoiceChip.button.rx.tap.asSignal(),
             photoChoiceChipTapped: scene.photoChoiceChip.button.rx.tap.asSignal(),
             videoChoiceChipTapped: scene.videoChoiceChip.button.rx.tap.asSignal(),

--- a/poporazzi/Feature/4.AlbumEdit/AlbumEditViewModel.swift
+++ b/poporazzi/Feature/4.AlbumEdit/AlbumEditViewModel.swift
@@ -177,6 +177,7 @@ extension AlbumEditViewModel {
                     id: oldAlbum.id,
                     title: albumTitle,
                     startDate: owner.output.startDate.value,
+                    endDate: owner.output.endDate.value,
                     excludeMediaList: oldAlbum.excludeMediaList,
                     mediaFetchOption: owner.output.mediaFetchOption.value,
                     mediaFilterOption: owner.output.mediaFilterOption.value

--- a/poporazzi/Feature/4.AlbumEdit/AlbumEditViewModel.swift
+++ b/poporazzi/Feature/4.AlbumEdit/AlbumEditViewModel.swift
@@ -36,7 +36,9 @@ extension AlbumEditViewModel {
     struct Input {
         let viewDidLoad: Signal<Void>
         let titleTextChanged: Signal<String>
+        
         let startDatePickerTapped: Signal<Void>
+        let endDatePickerTapped: Signal<Void>
         
         let allSaveChoiceChipTapped: Signal<Void>
         let photoChoiceChipTapped: Signal<Void>
@@ -55,6 +57,7 @@ extension AlbumEditViewModel {
         
         let titleText: BehaviorRelay<String>
         let startDate: BehaviorRelay<Date>
+        let endDate: BehaviorRelay<Date?>
         
         let mediaFetchOption: BehaviorRelay<MediaFetchOption>
         let mediaFilterOption: BehaviorRelay<MediaFilterOption>
@@ -63,13 +66,15 @@ extension AlbumEditViewModel {
     }
     
     enum Navigation {
-        case presentStartDatePicker(Date)
+        case presentStartDatePicker(startDate: Date, endDate: Date?)
+        case presentEndDatePicker(startDate: Date, endDate: Date?)
         case pop
         case dismissWithUpdate(Album)
     }
     
     enum Delegate {
         case startDateDidChanged(Date)
+        case endDateDidChanged(Date?)
     }
 }
 
@@ -90,7 +95,16 @@ extension AlbumEditViewModel {
         input.startDatePickerTapped
             .emit(with: self) { owner, _ in
                 let startDate = owner.output.startDate.value
-                owner.navigation.accept(.presentStartDatePicker(startDate))
+                let endDate = owner.output.endDate.value
+                owner.navigation.accept(.presentStartDatePicker(startDate: startDate, endDate: endDate))
+            }
+            .disposed(by: disposeBag)
+        
+        input.endDatePickerTapped
+            .emit(with: self) { owner, _ in
+                let startDate = owner.output.startDate.value
+                let endDate = owner.output.endDate.value
+                owner.navigation.accept(.presentEndDatePicker(startDate: startDate, endDate: endDate))
             }
             .disposed(by: disposeBag)
         
@@ -181,6 +195,9 @@ extension AlbumEditViewModel {
                 switch delegate {
                 case .startDateDidChanged(let date):
                     owner.output.startDate.accept(date)
+                    
+                case .endDateDidChanged(let date):
+                    owner.output.endDate.accept(date)
                 }
             }
             .disposed(by: disposeBag)

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
@@ -89,6 +89,7 @@ extension DatePickerModalView {
     enum Action {
         case setupSelectableStartDateRange(endDate: Date?)
         case setupSelectableEndDateRange(startDate: Date)
+        case toggleEndOfRecordCheckBox(Bool)
     }
     
     func action(_ action: Action) {
@@ -98,6 +99,19 @@ extension DatePickerModalView {
             
         case let .setupSelectableEndDateRange(startDate):
             self.datePicker.minimumDate = startDate
+            
+        case let .toggleEndOfRecordCheckBox(isActive):
+            if isActive {
+                self.endOfRecordCheckBox.action(.updateVariation(.selected))
+                UIView.animate(withDuration: 0.2) { [weak self] in
+                    self?.datePicker.isEnabled = false
+                }
+            } else {
+                self.endOfRecordCheckBox.action(.updateVariation(.deselected))
+                UIView.animate(withDuration: 0.2) { [weak self] in
+                    self?.datePicker.isEnabled = true
+                }
+            }
         }
     }
 }

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
@@ -18,13 +18,19 @@ final class DatePickerModalView: CodeBaseUI {
     let datePicker: UIDatePicker = {
         let datePicker = UIDatePicker()
         datePicker.datePickerMode = .dateAndTime
-        datePicker.preferredDatePickerStyle = .wheels
+        datePicker.preferredDatePickerStyle = .inline
         datePicker.locale = Locale(identifier: "ko-KR")
         datePicker.maximumDate = .now
+        datePicker.tintColor = .brandPrimary
+        datePicker.minuteInterval = 10
         return datePicker
     }()
     
-    let confirmButton = ActionButton(title: "확인", variataion: .secondary)
+    let actionbuttonView = UIView()
+    
+    let cancelButton = ActionButton(title: "취소", variataion: .secondary)
+    
+    let confirmButton = ActionButton(title: "시작 시간 저장", variataion: .primary)
     
     init() {
         super.init(frame: .zero)
@@ -47,10 +53,14 @@ final class DatePickerModalView: CodeBaseUI {
 extension DatePickerModalView {
     
     func configLayout() {
-        containerView.flex.direction(.column).paddingHorizontal(20).define { flex in
-            flex.addItem(datePicker).alignSelf(.center).marginTop(24)
-            flex.addItem().grow(1)
-            flex.addItem(confirmButton).marginBottom(8)
+        containerView.flex.direction(.column).define { flex in
+            flex.addItem(datePicker).position(.absolute).top(12).horizontally(20).bottom(24)
+            flex.addItem(actionbuttonView).position(.absolute).bottom(8).horizontally(20)
+        }
+        
+        actionbuttonView.flex.direction(.row).justifyContent(.spaceBetween).define { flex in
+            flex.addItem(cancelButton).grow(1).maxWidth(50%)
+            flex.addItem(confirmButton).grow(1).maxWidth(50%).marginLeft(12)
         }
     }
 }

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
@@ -50,7 +50,6 @@ final class DatePickerModalView: CodeBaseUI {
         datePicker.datePickerMode = .dateAndTime
         datePicker.preferredDatePickerStyle = .inline
         datePicker.locale = Locale(identifier: "ko-KR")
-        datePicker.maximumDate = .now
         datePicker.tintColor = .brandPrimary
         datePicker.minuteInterval = 10
         return datePicker
@@ -58,7 +57,7 @@ final class DatePickerModalView: CodeBaseUI {
     
     let endOfRecordCheckBox = FormCheckBox("기록 종료 시 까지", variation: .deselected)
     
-    let actionbuttonView = UIView()
+    private let actionbuttonView = UIView()
     
     let cancelButton = ActionButton(title: "취소", variataion: .secondary)
     
@@ -80,6 +79,26 @@ final class DatePickerModalView: CodeBaseUI {
         super.layoutSubviews()
         containerView.pin.all(pin.safeArea)
         containerView.flex.layout()
+    }
+}
+
+// MARK: - Action
+
+extension DatePickerModalView {
+    
+    enum Action {
+        case setupSelectableStartDateRange(endDate: Date?)
+        case setupSelectableEndDateRange(startDate: Date)
+    }
+    
+    func action(_ action: Action) {
+        switch action {
+        case let .setupSelectableStartDateRange(endDate):
+            self.datePicker.maximumDate = endDate
+            
+        case let .setupSelectableEndDateRange(startDate):
+            self.datePicker.minimumDate = startDate
+        }
     }
 }
 

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
@@ -11,9 +11,39 @@ import FlexLayout
 
 final class DatePickerModalView: CodeBaseUI {
     
+    enum Variation {
+        case startDate
+        case endDate
+        
+        var sheetHeight: CGFloat {
+            switch self {
+            case .startDate: 504
+            case .endDate: 544
+            }
+        }
+        
+        var title: String {
+            switch self {
+            case .startDate: "시작 시간 설정"
+            case .endDate: "종료 시간 설정"
+            }
+        }
+        
+        var info: String {
+            switch self {
+            case .startDate: "선택한 시간부터 앨범이 기록돼요"
+            case .endDate: "선택한 시간까지 앨범이 기록돼요"
+            }
+        }
+    }
+    
     var containerView = UIView()
     
-    let tapGesture = UITapGestureRecognizer()
+    var variation: Variation
+    
+    private let titleLabel = UILabel(size: 18, color: .mainLabel)
+    
+    private let infoLabel = UILabel(size: 14, color: .subLabel)
     
     let datePicker: UIDatePicker = {
         let datePicker = UIDatePicker()
@@ -26,14 +56,19 @@ final class DatePickerModalView: CodeBaseUI {
         return datePicker
     }()
     
+    let endOfRecordCheckBox = FormCheckBox("기록 종료 시 까지", variation: .deselected)
+    
     let actionbuttonView = UIView()
     
     let cancelButton = ActionButton(title: "취소", variataion: .secondary)
     
-    let confirmButton = ActionButton(title: "시작 시간 저장", variataion: .primary)
+    let confirmButton = ActionButton(title: "확인", variataion: .primary)
     
-    init() {
+    init(variation: Variation) {
+        self.variation = variation
         super.init(frame: .zero)
+        self.titleLabel.text = variation.title
+        self.infoLabel.text = variation.info
         setup()
     }
     
@@ -54,8 +89,15 @@ extension DatePickerModalView {
     
     func configLayout() {
         containerView.flex.direction(.column).define { flex in
-            flex.addItem(datePicker).position(.absolute).top(12).horizontally(20).bottom(24)
-            flex.addItem(actionbuttonView).position(.absolute).bottom(8).horizontally(20)
+            flex.addItem(titleLabel).marginTop(28).alignSelf(.center)
+            flex.addItem(infoLabel).marginTop(6).alignSelf(.center)
+            flex.addItem(datePicker).marginTop(0).alignSelf(.center)
+            
+            if variation == .endDate {
+                flex.addItem(endOfRecordCheckBox).marginTop(0).alignSelf(.center)
+            }
+            
+            flex.addItem(actionbuttonView).marginTop(16).marginHorizontal(20)
         }
         
         actionbuttonView.flex.direction(.row).justifyContent(.spaceBetween).define { flex in

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalView.swift
@@ -17,8 +17,8 @@ final class DatePickerModalView: CodeBaseUI {
         
         var sheetHeight: CGFloat {
             switch self {
-            case .startDate: 504
-            case .endDate: 544
+            case .startDate: 512
+            case .endDate: 552
             }
         }
         

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewController.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewController.swift
@@ -51,19 +51,32 @@ extension DatePickerModalViewController {
         let action = DatePickerModalViewModel.Input(
             viewWillAppear: viewWillAppear.asSignal(),
             datePickerChanged: scene.datePicker.rx.value.changed.asSignal(),
+            endOfRecordCheckBoxTapped: scene.endOfRecordCheckBox.tapGesture.rx.event.asVoidSignal(),
             confirmButtonTapped: scene.confirmButton.button.rx.tap.asSignal()
         )
-        let state = viewModel.transform(action)
+        let output = viewModel.transform(action)
         
-        state.setupSelectableStartDateRange
+        output.updateDate
+            .bind(with: self) { owner, date in
+                owner.scene.datePicker.setDate(date, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        output.setupSelectableStartDateRange
             .bind(with: self) { owner, date in
                 owner.scene.action(.setupSelectableStartDateRange(endDate: date))
             }
             .disposed(by: disposeBag)
         
-        state.setupSelectableEndDateRange
+        output.setupSelectableEndDateRange
             .bind(with: self) { owner, date in
                 owner.scene.action(.setupSelectableEndDateRange(startDate: date))
+            }
+            .disposed(by: disposeBag)
+        
+        output.isEndOfRecordActive
+            .bind(with: self) { owner, isActive in
+                owner.scene.action(.toggleEndOfRecordCheckBox(isActive))
             }
             .disposed(by: disposeBag)
     }

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewController.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewController.swift
@@ -52,6 +52,7 @@ extension DatePickerModalViewController {
             viewWillAppear: viewWillAppear.asSignal(),
             datePickerChanged: scene.datePicker.rx.value.changed.asSignal(),
             endOfRecordCheckBoxTapped: scene.endOfRecordCheckBox.tapGesture.rx.event.asVoidSignal(),
+            cancelButtonTapped: scene.cancelButton.button.rx.tap.asSignal(),
             confirmButtonTapped: scene.confirmButton.button.rx.tap.asSignal()
         )
         let output = viewModel.transform(action)

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewController.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewController.swift
@@ -11,14 +11,16 @@ import RxCocoa
 
 final class DatePickerModalViewController: ViewController {
     
-    private let scene = DatePickerModalView()
+    private let scene: DatePickerModalView
     private let viewModel: DatePickerModalViewModel
     
     let disposeBag = DisposeBag()
     
-    init(viewModel: DatePickerModalViewModel) {
+    init(viewModel: DatePickerModalViewModel, variation: DatePickerModalView.Variation) {
         self.viewModel = viewModel
+        self.scene = DatePickerModalView(variation: variation)
         super.init(nibName: nil, bundle: nil)
+        self.sheetPresentationController?.detents = [.custom(resolver: { _ in variation.sheetHeight })]
     }
     
     override func loadView() {
@@ -47,10 +49,10 @@ extension DatePickerModalViewController {
         )
         let state = viewModel.transform(action)
         
-        state.selectedDate
-            .bind(with: self) { owner, date in
-                owner.scene.datePicker.date = date
-            }
-            .disposed(by: disposeBag)
+//        state.selectedDate
+//            .bind(with: self) { owner, date in
+//                owner.scene.datePicker.date = date ?? .now
+//            }
+//            .disposed(by: disposeBag)
     }
 }

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewModel.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewModel.swift
@@ -104,7 +104,7 @@ extension DatePickerModalViewModel {
                 if isActive {
                     owner.output.endDate.accept(nil)
                 } else {
-                    owner.output.endDate.accept(.now)
+                    owner.output.endDate.accept(.now.roundDownMinutes)
                 }
             }
             .disposed(by: disposeBag)

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewModel.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewModel.swift
@@ -33,6 +33,7 @@ extension DatePickerModalViewModel {
         let viewWillAppear: Signal<Void>
         let datePickerChanged: Signal<Date>
         let endOfRecordCheckBoxTapped: Signal<Void>
+        let cancelButtonTapped: Signal<Void>
         let confirmButtonTapped: Signal<Void>
     }
     
@@ -48,6 +49,7 @@ extension DatePickerModalViewModel {
     }
     
     enum Navigation {
+        case pop
         case popFromStartDate(Date)
         case popFromEndDate(Date?)
     }
@@ -103,9 +105,16 @@ extension DatePickerModalViewModel {
                 
                 if isActive {
                     owner.output.endDate.accept(nil)
+                    HapticManager.impact(style: .soft)
                 } else {
                     owner.output.endDate.accept(.now.roundDownMinutes)
                 }
+            }
+            .disposed(by: disposeBag)
+        
+        input.cancelButtonTapped
+            .emit(with: self) { owner, _ in
+                owner.navigation.accept(.pop)
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewModel.swift
+++ b/poporazzi/Feature/5.DatePickerModal/DatePickerModalViewModel.swift
@@ -18,6 +18,10 @@ final class DatePickerModalViewModel: ViewModel {
     
     init(output: Output) {
         self.output = output
+//        switch output.modalState.value {
+//        case let .startDate(date): output.selectedDate.accept(date)
+//        case let .endDate(date): output.selectedDate.accept(date)
+//        }
     }
     
     deinit {
@@ -36,11 +40,19 @@ extension DatePickerModalViewModel {
     }
     
     struct Output {
-        let selectedDate: BehaviorRelay<Date>
+        let modalState: BehaviorRelay<ModalState>
+        let startDate: BehaviorRelay<Date>
+        let endDate: BehaviorRelay<Date?>
     }
     
     enum Navigation {
-        case pop(Date)
+        case popFromStartDate(Date)
+        case popFromEndDate(Date?)
+    }
+    
+    enum ModalState {
+        case startDate
+        case endDate
     }
 }
 
@@ -51,13 +63,23 @@ extension DatePickerModalViewModel {
     func transform(_ input: Input) -> Output {
         input.datePickerChanged
             .emit(with: self) { owner, date in
-                owner.output.selectedDate.accept(date)
+                switch owner.output.modalState.value {
+                case .startDate: owner.output.startDate.accept(date)
+                case .endDate: owner.output.endDate.accept(date)
+                }
             }
             .disposed(by: disposeBag)
         
         input.confirmButtonTapped
             .emit(with: self) { owner, _ in
-                owner.navigation.accept(.pop(owner.output.selectedDate.value))
+                switch owner.output.modalState.value {
+                case .startDate:
+                    owner.navigation.accept(.popFromStartDate(owner.output.startDate.value))
+                    
+                case .endDate:
+                    owner.navigation.accept(.popFromEndDate(owner.output.endDate.value))
+                }
+                
                 HapticManager.impact(style: .soft)
             }
             .disposed(by: disposeBag)

--- a/poporazzi/UIComponent/FormDatePicker.swift
+++ b/poporazzi/UIComponent/FormDatePicker.swift
@@ -32,11 +32,11 @@ final class FormDatePicker: CodeBaseUI {
         setup()
         addGestureRecognizer(tapGesture)
         
-        if title.isEmpty {
-            action(.updateDate(.now))
-        } else {
-            action(.setTitle(title))
-        }
+//        if title.isEmpty {
+//            action(.updateDate(.now))
+//        } else {
+//            action(.setTitle(title))
+//        }
     }
     
     required init?(coder: NSCoder) {
@@ -56,7 +56,7 @@ extension FormDatePicker {
     
     enum Action {
         case setTitle(String)
-        case updateDate(Date)
+        case updateDateLabel(String)
     }
     
     func action(_ action: Action) {
@@ -65,8 +65,8 @@ extension FormDatePicker {
             dateLabel.text = title
             dateLabel.flex.markDirty()
             
-        case let .updateDate(date):
-            dateLabel.text = date.startDateFullFormat
+        case let .updateDateLabel(title):
+            dateLabel.text = title
             dateLabel.flex.markDirty()
         }
     }

--- a/poporazzi/UIComponent/FormDatePicker.swift
+++ b/poporazzi/UIComponent/FormDatePicker.swift
@@ -17,12 +17,7 @@ final class FormDatePicker: CodeBaseUI {
     let tapGesture = UITapGestureRecognizer()
     
     /// 날짜 라벨
-    private let dateLabel: UILabel = {
-        let label = UILabel()
-        label.font = .setDovemayo(18)
-        label.textColor = .mainLabel
-        return label
-    }()
+    private let dateLabel = UILabel(size: 18, color: .mainLabel)
     
     /// 오른쪽 화살표
     private let chevronRight = UIImageView(
@@ -32,11 +27,16 @@ final class FormDatePicker: CodeBaseUI {
         tintColor: .subLabel
     )
     
-    init() {
+    init(title: String = "") {
         super.init(frame: .zero)
         setup()
         addGestureRecognizer(tapGesture)
-        action(.updateDate(.now))
+        
+        if title.isEmpty {
+            action(.updateDate(.now))
+        } else {
+            action(.setTitle(title))
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -55,11 +55,16 @@ final class FormDatePicker: CodeBaseUI {
 extension FormDatePicker {
     
     enum Action {
+        case setTitle(String)
         case updateDate(Date)
     }
     
     func action(_ action: Action) {
         switch action {
+        case let .setTitle(title):
+            dateLabel.text = title
+            dateLabel.flex.markDirty()
+            
         case let .updateDate(date):
             dateLabel.text = date.startDateFullFormat
             dateLabel.flex.markDirty()

--- a/poporazzi/Utility/Date+.swift
+++ b/poporazzi/Utility/Date+.swift
@@ -1,0 +1,22 @@
+//
+//  Date+.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/17/25.
+//
+
+import Foundation
+
+extension Date {
+    
+    /// 10분 단위로 반내림 후 반환합니다.
+    var roundDownMinutes: Date {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: self)
+        
+        var newComponents = components
+        newComponents.minute = (components.minute ?? 0) / 10 * 10
+        newComponents.second = 0
+        return calendar.date(from: newComponents) ?? self
+    }
+}

--- a/poporazzi/Utility/Formatter+.swift
+++ b/poporazzi/Utility/Formatter+.swift
@@ -36,6 +36,12 @@ extension Date {
         return Date.dateFormatter.string(from: self)
     }
     
+    /// 종료 날짜 전체 포맷을 반환합니다.
+    var endDateFullFormat: String {
+        Date.dateFormatter.dateFormat = "~ yyyy년 M월 d일 EEEE a h시 mm분"
+        return Date.dateFormatter.string(from: self)
+    }
+    
     /// Section의 Header 포맷을 반환합니다.
     var sectionHeaderFormat: String {
         Date.dateFormatter.dateFormat = "M월 d일 EEEE"

--- a/poporazzi/Utility/Formatter+.swift
+++ b/poporazzi/Utility/Formatter+.swift
@@ -32,13 +32,13 @@ extension Date {
     
     /// 시작 날짜 전체 포맷을 반환합니다.
     var startDateFullFormat: String {
-        Date.dateFormatter.dateFormat = "yyyy년 M월 d일 EEEE a h시 mm분~"
+        Date.dateFormatter.dateFormat = "yyyy. M. d(E) a h:mm 부터"
         return Date.dateFormatter.string(from: self)
     }
     
     /// 종료 날짜 전체 포맷을 반환합니다.
     var endDateFullFormat: String {
-        Date.dateFormatter.dateFormat = "~ yyyy년 M월 d일 EEEE a h시 mm분"
+        Date.dateFormatter.dateFormat = "yyyy. M. d(E) a h:mm 까지"
         return Date.dateFormatter.string(from: self)
     }
     


### PR DESCRIPTION
close #100

## *⛳️ Work Description*
- DatePickerModalView UI 업데이트 (Wheel -> inline)
- 종료 시간 추가 기능 구현(앨범 저장까지 반영)

## *🧐 트러블슈팅*
### 1. 시작 시간 + 종료 시간 사진 불러오기
creationDate에 조건을 추가해 구현할 수 있었습니다. `Album`의 `endDate`가 nil일 경우, 기록 종료 시 까지 트래킹 하는 것으로 간주했습니다.
~~~swift
// 시작 날짜 설정
var result = format + " AND " + "creationDate >= %@"
arguments.append(album.startDate as NSDate)

// 종료 날짜 설정
if let endDate = album.endDate {
    result += " AND " + "creationDate <= %@"
    arguments.append(endDate as NSDate)
}
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|시작 및 종료 시간 추가|<img width="300" alt="" src="https://github.com/user-attachments/assets/1d29a571-c43b-4ab1-b92f-508e5df4a750">|
|시작 시간 선택 Modal|<img width="300" alt="" src="https://github.com/user-attachments/assets/ddc4e42f-b457-4e1d-9ffd-5012c873dcc4">|
|종료 시간 선택 Modal|<img width="300" alt="" src="https://github.com/user-attachments/assets/a7848ace-bc95-49c4-84fe-17f23a84c80a">|