### PR TITLE
선택모드 UI 업데이트

### DIFF
--- a/poporazzi/Feature/3.Record/RecordView.swift
+++ b/poporazzi/Feature/3.Record/RecordView.swift
@@ -255,7 +255,11 @@ extension RecordView {
                     $0.action(.toggleDisabled(true))
                 }
             } else {
-                toolBar.action(.updateTitle("\(count)장의 기록이 선택됨"))
+                let attributedText = NSMutableAttributedString()
+                    .tint("\(count)장", color: .brandPrimary)
+                    .tint("의 기록이 선택됨", color: .mainLabel)
+                
+                toolBar.action(.updateTitle(AttributedString(attributedText)))
                 [favoriteToolBarButton, excludeToolBarButton, seemoreToolBarButton, removeToolBarButton].forEach {
                     $0.action(.toggleDisabled(false))
                 }

--- a/poporazzi/Feature/3.Record/RecordView.swift
+++ b/poporazzi/Feature/3.Record/RecordView.swift
@@ -32,11 +32,7 @@ final class RecordView: CodeBaseUI {
     }()
     
     /// 더보기 버튼
-    let seemoreButton: NavigationButton = {
-        let button = NavigationButton(buttonType: .seemore)
-        button.button.showsMenuAsPrimaryAction = true
-        return button
-    }()
+    let seemoreButton = NavigationButton(buttonType: .seemore)
     
     /// 선택 버튼
     let selectButton = NavigationButton(buttonType: .text("선택"), variation: .secondary)
@@ -244,11 +240,13 @@ extension RecordView {
             }
             
         case let .toggleSelectMode(bool):
-            recordCollectionView.contentInset.bottom = bool ? 56 : 0
             recordCollectionView.allowsSelection = bool
             recordCollectionView.allowsMultipleSelection = bool
             [seemoreButton, selectButton, finishRecordButton].forEach { $0.isHidden = bool }
             [selectCancelButton, toolBar].forEach { $0.isHidden = !bool }
+            UIView.animate(withDuration: 0.2) { [weak self] in
+                self?.recordCollectionView.contentInset.bottom = bool ? 80 : 0
+            }
             
         case let .updateSelectedCountLabel(count):
             if count == 0 {

--- a/poporazzi/Feature/3.Record/RecordView.swift
+++ b/poporazzi/Feature/3.Record/RecordView.swift
@@ -54,18 +54,25 @@ final class RecordView: CodeBaseUI {
     /// ToolBar
     lazy var toolBar: ToolBar = {
         let toolBar = ToolBar(
-            leading: excludeButton,
-            trailing: removeButton
+            leading: favoriteToolBarButton,
+            centers: [excludeToolBarButton, seemoreToolBarButton],
+            trailing: removeToolBarButton
         )
         toolBar.isHidden = true
         return toolBar
     }()
     
-    /// 앨범에서 제외 버튼
-    let excludeButton = ToolBarButton(title: "앨범에서 제외")
+    /// 즐겨찾기 툴 바 버튼
+    let favoriteToolBarButton = ToolBarButton(.favorite)
     
-    /// 삭제 버튼
-    let removeButton = ToolBarButton(title: "삭제")
+    /// 앨범에서 제외 툴 바 버튼
+    let excludeToolBarButton = ToolBarButton(.title("앨범에서 제외"))
+    
+    /// 더보기 툴 바 버튼
+    let seemoreToolBarButton = ToolBarButton(.seemore)
+    
+    /// 삭제 툴 바 버튼
+    let removeToolBarButton = ToolBarButton(.remove)
     
     /// 앨범 제목 라벨
     private let albumTitleLabel: UILabel = {
@@ -245,16 +252,14 @@ extension RecordView {
             
         case let .updateSelectedCountLabel(count):
             if count == 0 {
-                toolBar.action(.updateTitle("기록 선택"))
-                [excludeButton, removeButton].forEach {
-                    $0.alpha = 0.3
-                    $0.isUserInteractionEnabled = false
+                toolBar.action(.updateTitle("기록을 선택해주세요"))
+                [favoriteToolBarButton, excludeToolBarButton, seemoreToolBarButton, removeToolBarButton].forEach {
+                    $0.action(.toggleDisabled(true))
                 }
             } else {
                 toolBar.action(.updateTitle("\(count)장의 기록이 선택됨"))
-                [excludeButton, removeButton].forEach {
-                    $0.alpha = 1
-                    $0.isUserInteractionEnabled = true
+                [favoriteToolBarButton, excludeToolBarButton, seemoreToolBarButton, removeToolBarButton].forEach {
+                    $0.action(.toggleDisabled(false))
                 }
             }
             

--- a/poporazzi/Feature/3.Record/RecordViewController.swift
+++ b/poporazzi/Feature/3.Record/RecordViewController.swift
@@ -171,8 +171,9 @@ extension RecordViewController {
             recentIndexPath: recentIndexPath,
             recordCellSelected: scene.recordCollectionView.rx.itemSelected.asSignal(),
             recordCellDeselected: scene.recordCollectionView.rx.itemDeselected.asSignal(),
-            excludeButtonTapped: scene.excludeToolBarButton.button.rx.tap.asSignal(),
-            removeButtonTapped: scene.removeToolBarButton.button.rx.tap.asSignal(),
+            favoriteToolbarButtonTapped: scene.favoriteToolBarButton.button.rx.tap.asSignal(),
+            excludeToolbarButtonTapped: scene.excludeToolBarButton.button.rx.tap.asSignal(),
+            removeToolbarButtonTapped: scene.removeToolBarButton.button.rx.tap.asSignal(),
             finishButtonTapped: scene.finishRecordButton.button.rx.tap.asSignal()
         )
         let output = viewModel.transform(input)
@@ -225,7 +226,15 @@ extension RecordViewController {
         
         output.setupSeeMoreMenu
             .bind(with: self) { owner, menus in
+                owner.scene.seemoreButton.button.showsMenuAsPrimaryAction = true
                 owner.scene.seemoreButton.button.menu = menus.toUIMenu
+            }
+            .disposed(by: disposeBag)
+        
+        output.setupSeeMoreToolbarMenu
+            .bind(with: self) { owner, menus in
+                owner.scene.seemoreToolBarButton.button.showsMenuAsPrimaryAction = true
+                owner.scene.seemoreToolBarButton.button.menu = menus.toUIMenu
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/3.Record/RecordViewController.swift
+++ b/poporazzi/Feature/3.Record/RecordViewController.swift
@@ -171,8 +171,8 @@ extension RecordViewController {
             recentIndexPath: recentIndexPath,
             recordCellSelected: scene.recordCollectionView.rx.itemSelected.asSignal(),
             recordCellDeselected: scene.recordCollectionView.rx.itemDeselected.asSignal(),
-            excludeButtonTapped: scene.excludeButton.button.rx.tap.asSignal(),
-            removeButtonTapped: scene.removeButton.button.rx.tap.asSignal(),
+            excludeButtonTapped: scene.excludeToolBarButton.button.rx.tap.asSignal(),
+            removeButtonTapped: scene.removeToolBarButton.button.rx.tap.asSignal(),
             finishButtonTapped: scene.finishRecordButton.button.rx.tap.asSignal()
         )
         let output = viewModel.transform(input)

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -47,8 +47,9 @@ extension RecordViewModel {
         let recentIndexPath: BehaviorRelay<IndexPath>
         let recordCellSelected: Signal<IndexPath>
         let recordCellDeselected: Signal<IndexPath>
-        let excludeButtonTapped: Signal<Void>
-        let removeButtonTapped: Signal<Void>
+        let favoriteToolbarButtonTapped: Signal<Void>
+        let excludeToolbarButtonTapped: Signal<Void>
+        let removeToolbarButtonTapped: Signal<Void>
         let finishButtonTapped: Signal<Void>
     }
     
@@ -63,6 +64,7 @@ extension RecordViewModel {
         
         let viewDidRefresh = PublishRelay<Void>()
         let setupSeeMoreMenu = BehaviorRelay<[MenuModel]>(value: [])
+        let setupSeeMoreToolbarMenu = BehaviorRelay<[MenuModel]>(value: [])
         let switchSelectMode = PublishRelay<Bool>()
         let alertPresented = PublishRelay<AlertModel>()
         let actionSheetPresented = PublishRelay<ActionSheetModel>()
@@ -128,7 +130,8 @@ extension RecordViewModel {
         
         input.viewDidLoad
             .emit(with: self) { owner, _ in
-                owner.output.setupSeeMoreMenu.accept(self.seemoreMenu)
+                owner.output.setupSeeMoreMenu.accept(owner.seemoreMenu)
+                owner.output.setupSeeMoreToolbarMenu.accept(owner.seemoreToolbarMenu)
             }
             .disposed(by: disposeBag)
         
@@ -231,14 +234,21 @@ extension RecordViewModel {
             }
             .disposed(by: disposeBag)
         
-        input.excludeButtonTapped
+        input.favoriteToolbarButtonTapped
+            .emit(with: self) { owner, _ in
+                print("좋아요")
+                // TODO: 좋아요
+            }
+            .disposed(by: disposeBag)
+        
+        input.excludeToolbarButtonTapped
             .emit(with: self) { owner, _ in
                 owner.output.actionSheetPresented.accept(owner.excludeActionSheet)
                 HapticManager.notification(type: .warning)
             }
             .disposed(by: disposeBag)
         
-        input.removeButtonTapped
+        input.removeToolbarButtonTapped
             .emit(with: self) { owner, _ in
                 owner.output.actionSheetPresented.accept(owner.removeActionSheet)
                 HapticManager.notification(type: .warning)
@@ -509,5 +519,13 @@ extension RecordViewModel {
             self?.menuAction.accept(.noSave)
         }
         return [editAlbum, excludeRecord, noSave]
+    }
+    
+    /// 더보기 툴바 버튼 Menu
+    private var seemoreToolbarMenu: [MenuModel] {
+        let share = MenuModel(symbol: .share, title: "공유하기") { [weak self] in
+            print("공유하기!")
+        }
+        return [share]
     }
 }

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -96,6 +96,7 @@ extension RecordViewModel {
         case editAlbum
         case excludeRecord
         case noSave
+        case share
     }
 }
 
@@ -325,6 +326,9 @@ extension RecordViewModel {
                 case .noSave:
                     owner.output.alertPresented.accept(owner.finishWithNoSaveAlert)
                     HapticManager.notification(type: .warning)
+                    
+                case .share:
+                    print("공유하기!")
                 }
             }
             .disposed(by: disposeBag)
@@ -524,7 +528,7 @@ extension RecordViewModel {
     /// 더보기 툴바 버튼 Menu
     private var seemoreToolbarMenu: [MenuModel] {
         let share = MenuModel(symbol: .share, title: "공유하기") { [weak self] in
-            print("공유하기!")
+            self?.menuAction.accept(.share)
         }
         return [share]
     }

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
@@ -92,10 +92,10 @@ final class ExcludeRecordView: CodeBaseUI {
     }()
     
     /// 앨범으로 복구 버튼
-    let recoverButton = ToolBarButton(title: "앨범으로 복구")
+    let recoverButton = ToolBarButton(.title("앨범으로 복구"))
     
     /// 삭제 버튼
-    let removeButton = ToolBarButton(title: "삭제")
+    let removeButton = ToolBarButton(.remove)
     
     init() {
         super.init(frame: .zero)

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
@@ -157,7 +157,11 @@ extension ExcludeRecordView {
                     $0.action(.toggleDisabled(true))
                 }
             } else {
-                toolBar.action(.updateTitle("\(count)장의 기록이 선택됨"))
+                let attributedText = NSMutableAttributedString()
+                    .tint("\(count)장", color: .brandPrimary)
+                    .tint("의 기록이 선택됨", color: .mainLabel)
+                
+                toolBar.action(.updateTitle(AttributedString(attributedText)))
                 [favoriteToolBarButton, recoverToolBarButton, seemoreToolBarButton, removeToolBarButton].forEach {
                     $0.action(.toggleDisabled(false))
                 }

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
@@ -84,18 +84,25 @@ final class ExcludeRecordView: CodeBaseUI {
     /// ToolBar
     lazy var toolBar: ToolBar = {
         let toolBar = ToolBar(
-            leading: recoverButton,
-            trailing: removeButton
+            leading: favoriteToolBarButton,
+            centers: [recoverToolBarButton, seemoreToolBarButton],
+            trailing: removeToolBarButton
         )
         toolBar.isHidden = true
         return toolBar
     }()
     
-    /// 앨범으로 복구 버튼
-    let recoverButton = ToolBarButton(.title("앨범으로 복구"))
+    /// 즐겨찾기 툴 바 버튼
+    let favoriteToolBarButton = ToolBarButton(.favorite)
     
-    /// 삭제 버튼
-    let removeButton = ToolBarButton(.remove)
+    /// 앨범으로 복구 툴 바 버튼
+    let recoverToolBarButton = ToolBarButton(.title("앨범으로 복구"))
+    
+    /// 더보기 툴 바 버튼
+    let seemoreToolBarButton = ToolBarButton(.seemore)
+    
+    /// 삭제 툴 바 버튼
+    let removeToolBarButton = ToolBarButton(.remove)
     
     init() {
         super.init(frame: .zero)
@@ -135,24 +142,24 @@ extension ExcludeRecordView {
             emptyLabel.isHidden = count > 0
             
         case let .toggleSelectMode(bool):
-            recordCollectionView.contentInset.bottom = bool ? 56 : 0
             recordCollectionView.allowsSelection = bool
             recordCollectionView.allowsMultipleSelection = bool
             [selectButton].forEach { $0.isHidden = bool }
             [selectCancelButton, toolBar].forEach { $0.isHidden = !bool }
+            UIView.animate(withDuration: 0.2) { [weak self] in
+                self?.recordCollectionView.contentInset.bottom = bool ? 80 : 0
+            }
             
         case let .updateSelectedCountLabel(count):
             if count == 0 {
-                toolBar.action(.updateTitle("기록 선택"))
-                [recoverButton, removeButton].forEach {
-                    $0.alpha = 0.3
-                    $0.isUserInteractionEnabled = false
+                toolBar.action(.updateTitle("기록을 선택해주세요"))
+                [favoriteToolBarButton, recoverToolBarButton, seemoreToolBarButton, removeToolBarButton].forEach {
+                    $0.action(.toggleDisabled(true))
                 }
             } else {
                 toolBar.action(.updateTitle("\(count)장의 기록이 선택됨"))
-                [recoverButton, removeButton].forEach {
-                    $0.alpha = 1
-                    $0.isUserInteractionEnabled = true
+                [favoriteToolBarButton, recoverToolBarButton, seemoreToolBarButton, removeToolBarButton].forEach {
+                    $0.action(.toggleDisabled(false))
                 }
             }
             

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewController.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewController.swift
@@ -83,8 +83,9 @@ extension ExcludeRecordViewController {
             selectCancelButtonTapped: scene.selectCancelButton.button.rx.tap.asSignal(),
             recordCellSelected: scene.recordCollectionView.rx.itemSelected.asSignal(),
             recordCellDeselected: scene.recordCollectionView.rx.itemDeselected.asSignal(),
-            recoverButtonTapped: scene.recoverButton.button.rx.tap.asSignal(),
-            removeButtonTapped: scene.removeButton.button.rx.tap.asSignal()
+            favoriteToolbarButtonTapped: scene.favoriteToolBarButton.button.rx.tap.asSignal(),
+            recoverButtonTapped: scene.recoverToolBarButton.button.rx.tap.asSignal(),
+            removeButtonTapped: scene.removeToolBarButton.button.rx.tap.asSignal()
         )
         let output = viewModel.transform(input)
         
@@ -120,6 +121,13 @@ extension ExcludeRecordViewController {
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, actionSheet in
                 owner.showActionSheet(actionSheet)
+            }
+            .disposed(by: disposeBag)
+        
+        output.setupSeeMoreToolbarMenu
+            .bind(with: self) { owner, menu in
+                owner.scene.seemoreToolBarButton.button.showsMenuAsPrimaryAction = true
+                owner.scene.seemoreToolBarButton.button.menu = menu.toUIMenu
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/UIComponent/ToolBar.swift
+++ b/poporazzi/UIComponent/ToolBar.swift
@@ -65,14 +65,14 @@ final class ToolBar: CodeBaseUI {
 extension ToolBar {
     
     enum Action {
-        case updateTitle(String)
+        case updateTitle(AttributedString)
     }
     
     func action(_ action: Action) {
         switch action {
         case .updateTitle(let title):
             titleLabel.flex.markDirty()
-            titleLabel.text = title
+            titleLabel.attributedText = NSAttributedString(title)
         }
     }
 }

--- a/poporazzi/UIComponent/ToolBar.swift
+++ b/poporazzi/UIComponent/ToolBar.swift
@@ -24,19 +24,25 @@ final class ToolBar: CodeBaseUI {
         return label
     }()
     
-    private let leadingView: UIView
-    private let trailingView: UIView
+    private let leadings: UIView
+    private let centers: [UIView]
+    private let trailings: UIView
+    
+    private let buttons = UIView()
+    private let centerView = UIView()
     
     init(
         title: String = "",
         leading: UIView = UIView(),
+        centers: [UIView] = [],
         trailing: UIView = UIView()
     ) {
         self.titleLabel.text = title
-        self.leadingView = leading
-        self.trailingView = trailing
+        self.leadings = leading
+        self.centers = centers
+        self.trailings = trailing
         super.init(frame: .zero)
-        setup(color: .brandTertiary)
+        setup(color: .white)
     }
     
     required init?(coder: NSCoder) {
@@ -47,7 +53,10 @@ final class ToolBar: CodeBaseUI {
         super.layoutSubviews()
         containerView.pin.all(pin.safeArea)
         containerView.flex.layout()
-        containerView.addStroke([.top], color: .line, thickness: 1.5)
+        containerView.layer.shadowOffset = .init(width: 0, height: -1)
+        containerView.layer.shadowColor = UIColor.mainLabel.cgColor
+        containerView.layer.shadowOpacity = 0.08
+        containerView.layer.shadowRadius = 10
     }
 }
 
@@ -73,19 +82,25 @@ extension ToolBar {
 extension ToolBar {
     
     func configLayout() {
-        let bottomPadding: CGFloat = 16
-        containerView.flex.height(88)
-            .direction(.row)
-            .justifyContent(.center)
-            .alignItems(.center)
-            .paddingHorizontal(20)
-            .paddingBottom(bottomPadding)
+        containerView.flex.height(128)
+            .direction(.column)
+            .paddingHorizontal(16)
             .define { flex in
-                flex.addItem()
-                flex.addItem(titleLabel).position(.absolute).alignSelf(.center).horizontally(32).marginBottom(bottomPadding)
-                flex.addItem(leadingView)
-                flex.addItem().grow(1)
-                flex.addItem(trailingView)
+                flex.addItem(titleLabel).marginTop(16)
+                flex.addItem(buttons).marginTop(16)
             }
+        
+        centerView.flex.direction(.row).define { flex in
+            for (index, view) in centers.enumerated() {
+                flex.addItem(view)
+                    .marginLeft(index > 0 ? 8 : 0)
+            }
+        }
+        
+        buttons.flex.direction(.row).justifyContent(.spaceBetween).define { flex in
+            flex.addItem(leadings)
+            flex.addItem(centerView)
+            flex.addItem(trailings)
+        }
     }
 }

--- a/poporazzi/UIComponent/ToolBar.swift
+++ b/poporazzi/UIComponent/ToolBar.swift
@@ -55,7 +55,7 @@ final class ToolBar: CodeBaseUI {
         containerView.flex.layout()
         containerView.layer.shadowOffset = .init(width: 0, height: -1)
         containerView.layer.shadowColor = UIColor.mainLabel.cgColor
-        containerView.layer.shadowOpacity = 0.08
+        containerView.layer.shadowOpacity = 0.1
         containerView.layer.shadowRadius = 10
     }
 }

--- a/poporazzi/UIComponent/ToolBarButton.swift
+++ b/poporazzi/UIComponent/ToolBarButton.swift
@@ -11,17 +11,41 @@ import FlexLayout
 
 final class ToolBarButton: CodeBaseUI {
     
+    enum Variation {
+        case title(String)
+        case favorite
+        case seemore
+        case remove
+    }
+    
     var containerView = UIView()
     
     let tapGesture = UITapGestureRecognizer()
     
     var button = UIButton()
     
-    init(title: String) {
+    init(_ variation: Variation) {
         super.init(frame: .zero)
-        button.setTitle(title, for: .normal)
-        button.setTitleColor(.brandPrimary, for: .normal)
-        button.titleLabel?.font = .setDovemayo(15)
+        
+        switch variation {
+        case let .title(text):
+            button.setTitle(text, for: .normal)
+            button.setTitleColor(.subLabel, for: .normal)
+            button.titleLabel?.font = .setDovemayo(16)
+            
+        case .favorite:
+            button.setImage(UIImage(symbol: .likeActive, size: 16, weight: .bold), for: .normal)
+            button.tintColor = .subLabel
+            
+        case .seemore:
+            button.setImage(UIImage(symbol: .ellipsis, size: 16, weight: .black), for: .normal)
+            button.tintColor = .subLabel
+            
+        case .remove:
+            button.setImage(UIImage(symbol: .remove, size: 16, weight: .bold), for: .normal)
+            button.tintColor = .subLabel
+        }
+        
         setup()
         backgroundColor = .clear
         containerView.backgroundColor = .clear
@@ -49,8 +73,10 @@ extension ToolBarButton {
     func action(_ action: Action) {
         switch action {
         case let .toggleDisabled(bool):
-            self.alpha = bool ? 0.3 : 1
-            self.isUserInteractionEnabled = !bool
+            UIView.animate(withDuration: 0.2) { [weak self] in
+                self?.alpha = bool ? 0.4 : 1
+                self?.isUserInteractionEnabled = !bool
+            }
         }
     }
 }
@@ -61,7 +87,11 @@ extension ToolBarButton {
     
     func configLayout() {
         containerView.flex.define { flex in
-            flex.addItem(button).height(40)
+            flex.addItem(button)
+                .paddingHorizontal(16)
+                .backgroundColor(.brandSecondary)
+                .cornerRadius(19)
+                .height(38)
         }
     }
 }

--- a/poporazzi/Utility/NSMutableAttributedString+.swift
+++ b/poporazzi/Utility/NSMutableAttributedString+.swift
@@ -1,0 +1,18 @@
+//
+//  NSMutableAttributedString+.swift
+//  poporazzi
+//
+//  Created by 김민준 on 5/19/25.
+//
+
+import UIKit
+
+extension NSMutableAttributedString {
+    
+    /// 컬러를 적용 후 반환합니다.
+    func tint(_ text: String, color: UIColor) -> Self {
+        let attributes: [NSAttributedString.Key : Any] = [.foregroundColor: color]
+        self.append(NSAttributedString(string: text, attributes: attributes))
+        return self
+    }
+}

--- a/poporazzi/Utility/SFSymbol+.swift
+++ b/poporazzi/Utility/SFSymbol+.swift
@@ -21,6 +21,9 @@ enum SFSymbol: String {
     case check = "checkmark"
     case checkBox = "checkmark.square.fill"
     case noSave = "xmark.bin"
+    case likeInactive = "heart"
+    case likeActive = "heart.fill"
+    case remove = "trash.fill"
 }
 
 // MARK: - initializer

--- a/poporazzi/Utility/SFSymbol+.swift
+++ b/poporazzi/Utility/SFSymbol+.swift
@@ -24,6 +24,7 @@ enum SFSymbol: String {
     case likeInactive = "heart"
     case likeActive = "heart.fill"
     case remove = "trash.fill"
+    case share = "square.and.arrow.up"
 }
 
 // MARK: - initializer


### PR DESCRIPTION
close #106

## *⛳️ Work Description*
- 선택모드 ToolBar UI 업데이트
- 좋아요 및 더보기 버튼 연결(기능 구현 미완료)
- AttributedString 적용

## *🧐 트러블슈팅*
### 1. NSMutableAttributedString을 이용한 텍스트 컬러 지정
`NSMutableAttributedString`를 확장 후 tint 함수를 구현했습니다.
~~~swift
extension NSMutableAttributedString {
    
    /// 컬러를 적용 후 반환합니다.
    func tint(_ text: String, color: UIColor) -> Self {
        let attributes: [NSAttributedString.Key : Any] = [.foregroundColor: color]
        self.append(NSAttributedString(string: text, attributes: attributes))
        return self
    }
}
~~~

이후 아래와 같이 적용할 수 있었습니다.
~~~swift
let attributedText = NSMutableAttributedString()
    .tint("\(count)장", color: .brandPrimary)
    .tint("의 기록이 선택됨", color: .mainLabel)

toolBar.action(.updateTitle(AttributedString(attributedText)))
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|ToolBar UI 업데이트|<img width="300" alt="" src="https://github.com/user-attachments/assets/42c66f16-f4c5-4ab2-8ef7-18d81c376d1d">|