### PR TITLE
미디어 즐겨찾기 기능 구현

### DIFF
--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -42,6 +42,10 @@ struct MockPhotoKitService: PhotoKitInterface {
         return .just(array)
     }
     
+    func toggleFavorite(from assetIdentifiers: [String], isFavorite: Bool) {
+        print("즐겨찾기 완료")
+    }
+    
     func saveAlbumAsSingle(title: String, sectionMediaList: SectionMediaList)  -> Observable<Void> {
         print("[하나의 앨범으로 저장 완료] - \(title)")
         return .just(())

--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -23,7 +23,8 @@ struct MockPhotoKitService: PhotoKitInterface {
         Array(repeatElement(.init(
             id: UUID().uuidString,
             creationDate: .now,
-            mediaType: .photo(.selfShooting, .heic)
+            mediaType: .photo(.selfShooting, .heic),
+            isFavorite: false
         ), count: 30))
     }
     
@@ -34,7 +35,8 @@ struct MockPhotoKitService: PhotoKitInterface {
                 id: UUID().uuidString,
                 creationDate: .now,
                 mediaType: .photo(.selfShooting, .heic),
-                thumbnail: UIImage()
+                thumbnail: UIImage(),
+                isFavorite: false
             ))
         }
         return .just(array)

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -83,7 +83,8 @@ extension PhotoKitService {
                         id: asset.localIdentifier,
                         creationDate: asset.creationDate,
                         mediaType: mediaType,
-                        thumbnail: nil
+                        thumbnail: nil,
+                        isFavorite: asset.isFavorite
                     )
                     mediaList.append(media)
                 }
@@ -97,7 +98,8 @@ extension PhotoKitService {
                         id: asset.localIdentifier,
                         creationDate: asset.creationDate,
                         mediaType: mediaType,
-                        thumbnail: nil
+                        thumbnail: nil,
+                        isFavorite: asset.isFavorite
                     )
                     mediaList.append(media)
                 }
@@ -136,7 +138,8 @@ extension PhotoKitService {
                                 id: asset.localIdentifier,
                                 creationDate: asset.creationDate,
                                 mediaType: self.mediaType(from: asset),
-                                thumbnail: image
+                                thumbnail: image,
+                                isFavorite: asset.isFavorite
                             )
                         }
                     }

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -439,8 +439,10 @@ extension PhotoKitService: PHPhotoLibraryChangeObserver {
         /// 변화가 일어났는지 확인
         if changeDetails.hasIncrementalChanges {
             
-            // 추가 또는 삭제된 에셋이 있다면
-            if !changeDetails.insertedObjects.isEmpty || !changeDetails.removedObjects.isEmpty {
+            // 변경 추가 또는 삭제된 에셋이 있다면
+            if !changeDetails.changedObjects.isEmpty
+                || !changeDetails.insertedObjects.isEmpty
+                || !changeDetails.removedObjects.isEmpty {
                 photoLibraryChangeRelay.accept(())
             }
         }

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -156,6 +156,17 @@ extension PhotoKitService {
         }
     }
     
+    /// 즐겨찾기 상태를 전환합니다.
+    func toggleFavorite(from assetIdentifiers: [String], isFavorite: Bool) {
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: assetIdentifiers, options: nil)
+        PHPhotoLibrary.shared().performChanges {
+            assets.enumerateObjects { asset, _, _ in
+                let request = PHAssetChangeRequest(for: asset)
+                request.isFavorite = isFavorite
+            }
+        }
+    }
+    
     /// 하나의 앨범으로 만들어 저장합니다.
     func saveAlbumAsSingle(title: String, sectionMediaList: SectionMediaList) -> Observable<Void> {
         Observable.create { [weak self] observer in
@@ -436,7 +447,7 @@ extension PhotoKitService: PHPhotoLibraryChangeObserver {
             return
         }
         
-        /// 변화가 일어났는지 확인
+        // 변화가 일어났는지 확인
         if changeDetails.hasIncrementalChanges {
             
             // 변경 추가 또는 삭제된 에셋이 있다면

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -35,6 +35,7 @@ struct Media: Hashable, Equatable {
         lhs.id == rhs.id
         && lhs.mediaType == rhs.mediaType
         && lhs.thumbnail != rhs.thumbnail
+        && lhs.isFavorite == rhs.isFavorite
     }
     
     /// 미디어 타입

--- a/poporazzi/Domain/Entity/Media.swift
+++ b/poporazzi/Domain/Entity/Media.swift
@@ -24,6 +24,9 @@ struct Media: Hashable, Equatable {
     /// 썸네일
     var thumbnail: UIImage?
     
+    /// 즐겨찾기 여부
+    var isFavorite: Bool
+    
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -23,6 +23,9 @@ protocol PhotoKitInterface {
     /// Media 배열 이벤트를 반환합니다.
     func fetchMedias(from assetIdentifiers: [String]) -> Observable<[Media]>
     
+    /// 즐겨찾기 상태를 전환합니다.
+    func toggleFavorite(from assetIdentifiers: [String], isFavorite: Bool)
+    
     /// 하나의 앨범으로 만들어 저장합니다.
     func saveAlbumAsSingle(title: String, sectionMediaList: SectionMediaList) -> Observable<Void>
     

--- a/poporazzi/Feature/3.Record/RecordView.swift
+++ b/poporazzi/Feature/3.Record/RecordView.swift
@@ -178,6 +178,7 @@ extension RecordView {
         case updateInfoLabel(Album)
         case toggleEmptyLabel(Bool)
         case toggleSelectMode(Bool)
+        case toggleFavoriteMode(Bool)
         case updateSelectedCountLabel(Int)
         case toggleLoading(Bool)
     }
@@ -247,6 +248,10 @@ extension RecordView {
             UIView.animate(withDuration: 0.2) { [weak self] in
                 self?.recordCollectionView.contentInset.bottom = bool ? 80 : 0
             }
+            
+        case let .toggleFavoriteMode(bool):
+            let symbol = UIImage(symbol: bool ? .favoriteActive : .favoriteRemove, size: 16, weight: .bold)
+            favoriteToolBarButton.button.setImage(symbol, for: .normal)
             
         case let .updateSelectedCountLabel(count):
             if count == 0 {

--- a/poporazzi/Feature/3.Record/RecordViewController.swift
+++ b/poporazzi/Feature/3.Record/RecordViewController.swift
@@ -83,7 +83,7 @@ extension RecordViewController {
                 cell.action(.setImage(cacheThumbnail))
             }
             
-            cell.action(.setMediaType(media.mediaType))
+            cell.action(.setMediaInfo(media))
             
             return cell
         }

--- a/poporazzi/Feature/3.Record/RecordViewController.swift
+++ b/poporazzi/Feature/3.Record/RecordViewController.swift
@@ -238,7 +238,15 @@ extension RecordViewController {
             }
             .disposed(by: disposeBag)
         
+        output.shoudBeFavorite
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, bool in
+                owner.scene.action(.toggleFavoriteMode(bool))
+            }
+            .disposed(by: disposeBag)
+        
         output.switchSelectMode
+            .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, bool in
                 owner.scene.action(.toggleSelectMode(bool))
             }

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -369,9 +369,7 @@ extension RecordViewModel {
     
     /// IndexPath에 대응되는 Asset Identifiers를 반환합니다.
     private func selectedAssetIdentifiers() -> [String] {
-        output.selectedRecordCells.value.compactMap {
-            output.mediaList.value[index(from: $0)].id
-        }
+        selectedMediaList().map(\.id)
     }
     
     /// 시작날짜를 기준으로 생성일이 몇일차인지 반환합니다.

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -237,8 +237,20 @@ extension RecordViewModel {
         
         input.favoriteToolbarButtonTapped
             .emit(with: self) { owner, _ in
-                print("좋아요")
-                // TODO: 좋아요
+                let selectedMediaList = owner.selectedMediaList()
+                let isFavoriteSet = Set(selectedMediaList.map(\.isFavorite))
+                
+                var isFavorite = false
+                if isFavoriteSet.count > 1 {
+                    isFavorite = isFavoriteSet.contains(true)
+                } else {
+                    isFavorite = !(isFavoriteSet.first ?? false)
+                }
+                
+                owner.photoKitService.toggleFavorite(
+                    from: selectedMediaList.map(\.id),
+                    isFavorite: isFavorite
+                )
             }
             .disposed(by: disposeBag)
         
@@ -354,6 +366,13 @@ extension RecordViewModel {
 // MARK: - Helper
 
 extension RecordViewModel {
+    
+    /// IndexPath에 대응되는 Media를 반환합니다.
+    private func selectedMediaList() -> [Media] {
+        output.selectedRecordCells.value.compactMap {
+            output.mediaList.value[index(from: $0)]
+        }
+    }
     
     /// IndexPath에 대응되는 Asset Identifiers를 반환합니다.
     private func selectedAssetIdentifiers() -> [String] {

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordView.swift
@@ -130,6 +130,7 @@ extension ExcludeRecordView {
     enum Action {
         case setTotalImageCountLabel(Int)
         case toggleSelectMode(Bool)
+        case toggleFavoriteMode(Bool)
         case updateSelectedCountLabel(Int)
         case toggleLoading(Bool)
     }
@@ -149,6 +150,10 @@ extension ExcludeRecordView {
             UIView.animate(withDuration: 0.2) { [weak self] in
                 self?.recordCollectionView.contentInset.bottom = bool ? 80 : 0
             }
+            
+        case let .toggleFavoriteMode(bool):
+            let symbol = UIImage(symbol: bool ? .favoriteActive : .favoriteRemove, size: 16, weight: .bold)
+            favoriteToolBarButton.button.setImage(symbol, for: .normal)
             
         case let .updateSelectedCountLabel(count):
             if count == 0 {

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewController.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewController.swift
@@ -56,7 +56,7 @@ extension ExcludeRecordViewController {
             ) as? RecordCell else { return nil }
             
             cell.action(.setImage(media.thumbnail))
-            cell.action(.setMediaType(media.mediaType))
+            cell.action(.setMediaInfo(media))
             
             return cell
         }

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewController.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewController.swift
@@ -104,6 +104,13 @@ extension ExcludeRecordViewController {
             }
             .disposed(by: disposeBag)
         
+        output.shoudBeFavorite
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { owner, bool in
+                owner.scene.action(.toggleFavoriteMode(bool))
+            }
+            .disposed(by: disposeBag)
+        
         output.switchSelectMode
             .bind(with: self) { owner, bool in
                 owner.scene.action(.toggleSelectMode(bool))

--- a/poporazzi/UIComponent/RecordCollectionView/RecordCell.swift
+++ b/poporazzi/UIComponent/RecordCollectionView/RecordCell.swift
@@ -66,7 +66,7 @@ final class RecordCell: UICollectionViewCell {
     /// 셀 즐겨찾기 아이콘
     private let favoriteIcon: UIImageView = {
         let imageView = UIImageView(
-            symbol: .likeActive,
+            symbol: .favoriteActive,
             size: 12,
             weight: .bold,
             tintColor: .white

--- a/poporazzi/UIComponent/ToolBarButton.swift
+++ b/poporazzi/UIComponent/ToolBarButton.swift
@@ -34,7 +34,7 @@ final class ToolBarButton: CodeBaseUI {
             button.titleLabel?.font = .setDovemayo(16)
             
         case .favorite:
-            button.setImage(UIImage(symbol: .likeActive, size: 16, weight: .bold), for: .normal)
+            button.setImage(UIImage(symbol: .favoriteActive, size: 16, weight: .bold), for: .normal)
             button.tintColor = .subLabel
             
         case .seemore:

--- a/poporazzi/Utility/SFSymbol+.swift
+++ b/poporazzi/Utility/SFSymbol+.swift
@@ -21,8 +21,8 @@ enum SFSymbol: String {
     case check = "checkmark"
     case checkBox = "checkmark.square.fill"
     case noSave = "xmark.bin"
-    case likeInactive = "heart"
-    case likeActive = "heart.fill"
+    case favoriteRemove = "heart.slash.fill"
+    case favoriteActive = "heart.fill"
     case remove = "trash.fill"
     case share = "square.and.arrow.up"
 }


### PR DESCRIPTION
close #108

## *⛳️ Work Description*
- 미디어 즐겨찾기 기능 구현

## *🧐 트러블슈팅*
### 1. PHAsset 즐겨찾기 토글
request의 `isFavorite` 값을 업데이트해 구현할 수 있습니다.
~~~swift
/// 즐겨찾기 상태를 전환합니다.
func toggleFavorite(from assetIdentifiers: [String], isFavorite: Bool) {
    let assets = PHAsset.fetchAssets(withLocalIdentifiers: assetIdentifiers, options: nil)
    PHPhotoLibrary.shared().performChanges {
        assets.enumerateObjects { asset, _, _ in
            let request = PHAssetChangeRequest(for: asset)
            request.isFavorite = isFavorite
        }
    }
}
~~~

### 2. 소소한 트러블 슈팅 with Equatable
만약 DiffableDataSource를 사용하고 로직 상 맞는 것 같은데 데이터가 업데이트가 안된다,,? 그럼 Equatable 프로토콜의 기본 구현을 다시 살펴보는 것이 좋습니다. 이번 업데이트 때 `Media` Entity에 `isFavorite` 속성이 추가되었는데 `==` 기본 구현 함수에 이를 빼먹어 업데이트가 되지 않는 일이 발생했다,,!

~~~swift
static func == (lhs: Media, rhs: Media) -> Bool {
    lhs.id == rhs.id
    && lhs.mediaType == rhs.mediaType
    && lhs.thumbnail != rhs.thumbnail
    && lhs.isFavorite == rhs.isFavorite // ⭐️ 이게 빠져있었으니 CollectionView가 업데이트 되지 않았던 것!
}
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|즐겨찾기 구현|<img width="300" alt="" src="https://github.com/user-attachments/assets/41f43839-64ab-48ad-9680-54b5c2fa5664">|