### PR TITLE
미디어 공유하기 기능 구현

### DIFF
--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -106,6 +106,7 @@ extension Coordinator {
         self.navigationController.pushViewController(recordVC, animated: true)
         
         recordVM.navigation
+            .observe(on: MainScheduler.instance)
             .bind(with: self) { [weak recordVM] owner, path in
                 switch path {
                 case .pop:
@@ -119,6 +120,9 @@ extension Coordinator {
                     
                 case let .presentFinishModal(album, sectionMediaList):
                     owner.presentFinishModal(recordVM, album: album, sectionMediaList: sectionMediaList)
+                    
+                case let .presentMediaShareSheet(shareItemList):
+                    owner.presentMediaShareSheet(shareItemList)
                 }
             }
             .disposed(by: recordVC.disposeBag)
@@ -259,5 +263,19 @@ extension Coordinator {
                 }
             }
             .disposed(by: finishVC.disposeBag)
+    }
+}
+
+// MARK: - ActivityView
+
+extension Coordinator {
+    
+    /// Media 공유 Sheet를 출력합니다.
+    private func presentMediaShareSheet(_ shareItemList: [Any]) {
+        let activityController = UIActivityViewController(
+            activityItems: shareItemList,
+            applicationActivities: nil
+        )
+        self.navigationController.present(activityController, animated: true)
     }
 }

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -122,7 +122,17 @@ extension Coordinator {
                     owner.presentFinishModal(recordVM, album: album, sectionMediaList: sectionMediaList)
                     
                 case let .presentMediaShareSheet(shareItemList):
-                    owner.presentMediaShareSheet(shareItemList)
+                    let activityController = UIActivityViewController(
+                        activityItems: shareItemList,
+                        applicationActivities: nil
+                    )
+                    owner.navigationController.present(activityController, animated: true)
+                    
+                    activityController.completionWithItemsHandler = { _, isComplete, _, _ in
+                        if isComplete {
+                            recordVM?.delegate.accept(.completeSharing)
+                        }
+                    }
                 }
             }
             .disposed(by: recordVC.disposeBag)
@@ -263,19 +273,5 @@ extension Coordinator {
                 }
             }
             .disposed(by: finishVC.disposeBag)
-    }
-}
-
-// MARK: - ActivityView
-
-extension Coordinator {
-    
-    /// Media 공유 Sheet를 출력합니다.
-    private func presentMediaShareSheet(_ shareItemList: [Any]) {
-        let activityController = UIActivityViewController(
-            activityItems: shareItemList,
-            applicationActivities: nil
-        )
-        self.navigationController.present(activityController, animated: true)
     }
 }

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -86,6 +86,7 @@ extension Coordinator {
         self.navigationController.pushViewController(albumOptionVC, animated: true)
         
         albumOptionVM.navigation
+            .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, path in
                 switch path {
                 case .pop:
@@ -157,6 +158,7 @@ extension Coordinator {
         self.navigationController.pushViewController(editVC, animated: true)
         
         editVM.navigation
+            .observe(on: MainScheduler.instance)
             .bind(with: self) { [weak editVC] owner, path in
                 switch path {
                 case let .presentStartDatePicker(startDate, endDate):
@@ -183,11 +185,25 @@ extension Coordinator {
         self.navigationController.pushViewController(excludeRecordVC, animated: true)
         
         excludeRecordVM.navigation
-            .bind(with: self) { owner, path in
+            .observe(on: MainScheduler.instance)
+            .bind(with: self) { [weak excludeRecordVM] owner, path in
                 switch path {
                 case let .pop(album):
                     recordVM?.delegate.accept(.updateExcludeRecord(album))
                     owner.navigationController.popViewController(animated: true)
+                    
+                case let .presentMediaShareSheet(shareItemList):
+                    let activityController = UIActivityViewController(
+                        activityItems: shareItemList,
+                        applicationActivities: nil
+                    )
+                    owner.navigationController.present(activityController, animated: true)
+                    
+                    activityController.completionWithItemsHandler = { _, isComplete, _, _ in
+                        if isComplete {
+                            excludeRecordVM?.delegate.accept(.completeSharing)
+                        }
+                    }
                 }
             }
             .disposed(by: excludeRecordVC.disposeBag)
@@ -230,6 +246,7 @@ extension Coordinator {
         editVC?.present(datePickerVC, animated: true)
         
         datePickerVM.navigation
+            .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, path in
                 switch path {
                 case .pop:
@@ -262,6 +279,7 @@ extension Coordinator {
         self.navigationController.present(finishVC, animated: true)
         
         finishVM.navigation
+            .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, path in
                 switch path {
                 case .dismiss:

--- a/poporazzi/Data/Mock/MockPhotoKitService.swift
+++ b/poporazzi/Data/Mock/MockPhotoKitService.swift
@@ -59,4 +59,8 @@ struct MockPhotoKitService: PhotoKitInterface {
     func deletePhotos(from assetIdentifiers: [String]) -> Observable<Bool> {
         .just(true)
     }
+    
+    func fetchShareItemList(from assetIdentifiers: [String]) -> Observable<[Any]> {
+        .just([])
+    }
 }

--- a/poporazzi/Domain/Interface/PhotoKitInterface.swift
+++ b/poporazzi/Domain/Interface/PhotoKitInterface.swift
@@ -34,4 +34,7 @@ protocol PhotoKitInterface {
     
     /// 사진을 삭제 후 결과 이벤트를 반환합니다.
     func deletePhotos(from assetIdentifiers: [String]) -> Observable<Bool>
+    
+    /// 선택한 AssetIdentifiers의 공유 Item을 반환합니다.
+    func fetchShareItemList(from assetIdentifiers: [String]) -> Observable<[Any]>
 }

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -83,6 +83,7 @@ extension RecordViewModel {
     enum Delegate {
         case albumDidEdited(Album)
         case updateExcludeRecord(Album)
+        case completeSharing
     }
     
     enum AlertAction {
@@ -353,6 +354,9 @@ extension RecordViewModel {
                 case let .updateExcludeRecord(album):
                     owner.output.album.accept(album)
                     owner.output.viewDidRefresh.accept(())
+                    
+                case .completeSharing:
+                    owner.cancelSelectMode()
                 }
             }
             .disposed(by: disposeBag)

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -77,6 +77,7 @@ extension RecordViewModel {
         case pushAlbumEdit(Album)
         case presentExcludeRecord(Album)
         case presentFinishModal(Album, SectionMediaList)
+        case presentMediaShareSheet([Any])
     }
     
     enum Delegate {
@@ -333,7 +334,11 @@ extension RecordViewModel {
                     HapticManager.notification(type: .warning)
                     
                 case .share:
-                    print("공유하기!")
+                    owner.photoKitService.fetchShareItemList(from: owner.selectedAssetIdentifiers())
+                        .bind { shareItemList in
+                            owner.navigation.accept(.presentMediaShareSheet(shareItemList))
+                        }
+                        .disposed(by: owner.disposeBag)
                 }
             }
             .disposed(by: disposeBag)


### PR DESCRIPTION
close #110

## *⛳️ Work Description*
- 사진 및 동영상 공유하기 기능 구현

## *🧐 트러블슈팅*
### 1. UIActivityViewController를 이용한 사진 및 동영상 공유
ActivityViewController의 `activityItems`에 공유할 데이터를 전달하고, present하면 쉽게 공유 Sheet를 띄울 수 있습니다. 
~~~swift

// ⭐️ 1. ActivityViewController 생성
let activityController = UIActivityViewController(
    activityItems: shareItemList,
    applicationActivities: nil
)

// ⭐️ 2. 공유 Sheet 출력
owner.navigationController.present(activityController, animated: true)

// ⭐️ 3. 공유 Sheet 완료 후 처리
activityController.completionWithItemsHandler = { _, isComplete, _, _ in
    if isComplete {
        excludeRecordVM?.delegate.accept(.completeSharing)
    }
}
~~~

아직 해결하지 못한 부분은, 공유 Sheet 출력 시 상단 Title 부분을 조정하지 못한 것입니다.
<img width="300" alt="" src="https://github.com/user-attachments/assets/74278071-d1f3-48a5-acfa-7350682247ff">

해당 부분은 `UIActivityItemSource`를 이용해 Metadata를 설정함으로써 해결할 수 있었지만, [공식문서](https://developer.apple.com/documentation/uikit/uiactivityitemsource)에도 언급되어 있듯, 시간이 소요되는 작업이기 때문에 이미지 공유까지의 시간이 초과되어 정상적인 공유 기능이 동작하지 않음을 확인했습니다.(아래 언급된 UIActivityItemProvider를 사용해도 마찬가지였습니다.)

![image](https://github.com/user-attachments/assets/4f53d10d-0ae6-4a8a-b0e8-483df2ae3253)

크리티컬한 부분은 아니긴 하지만, 추후 트러블슈팅을 통해 해결이 필요합니다.

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|ActivitiyViewController|<img width="300" alt="" src="https://github.com/user-attachments/assets/df7ae73e-27a7-4126-8dbf-d7e760df39b8">|