### PR TITLE
CollectionView Context Menu 기능 구현

### DIFF
--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -191,9 +191,11 @@ extension Coordinator {
             .observe(on: MainScheduler.instance)
             .bind(with: self) { [weak excludeRecordVM] owner, path in
                 switch path {
-                case let .pop(album):
-                    recordVM?.delegate.accept(.updateExcludeRecord(album))
+                case .pop:
                     owner.navigationController.popViewController(animated: true)
+                    
+                case let .updateRecord(album):
+                    recordVM?.delegate.accept(.updateExcludeRecord(album))
                     
                 case let .presentMediaShareSheet(shareItemList):
                     let activityController = UIActivityViewController(

--- a/poporazzi/Data/Service/PhotoKitService.swift
+++ b/poporazzi/Data/Service/PhotoKitService.swift
@@ -38,6 +38,12 @@ final class PhotoKitService: NSObject, PhotoKitInterface {
     
     /// PhotoLibray의 변화가 감지할 때 이벤트를 발송하는 Relay
     private let photoLibraryChangeRelay = BehaviorRelay(value: ())
+    
+    override init() {
+        super.init()
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        if status == .authorized { PHPhotoLibrary.shared().register(self) }
+    }
 }
 
 // MARK: - UseCase

--- a/poporazzi/Feature/3.Record/RecordViewController.swift
+++ b/poporazzi/Feature/3.Record/RecordViewController.swift
@@ -35,6 +35,7 @@ final class RecordViewController: ViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupDataSource()
+        setupLongPressGesture()
         bind()
     }
     
@@ -156,6 +157,31 @@ extension RecordViewController {
         var snapshot = dataSource.snapshot()
         snapshot.reloadItems(mediaList)
         dataSource.apply(snapshot, animatingDifferences: true)
+    }
+}
+
+// MARK: - Long Press Gesture
+
+extension RecordViewController {
+    
+    /// Long Press Gesture를 세팅합니다.
+    private func setupLongPressGesture() {
+        let longPressGesture = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(handleLongPressGesture)
+        )
+        scene.recordCollectionView.addGestureRecognizer(longPressGesture)
+    }
+    
+    /// Long Press Gesture를 조작합니다.
+    @objc private func handleLongPressGesture(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began else { return }
+        
+        let point = gesture.location(in: scene.recordCollectionView)
+        guard let indexPath = scene.recordCollectionView.indexPathForItem(at: point) else {
+            return
+        }
+        print(indexPath)
     }
 }
 

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -380,7 +380,11 @@ extension RecordViewModel {
                     )
                     
                 case let .share(media):
-                    break
+                    owner.photoKitService.fetchShareItemList(from: [media.id])
+                        .bind { shareItemList in
+                            owner.navigation.accept(.presentMediaShareSheet(shareItemList))
+                        }
+                        .disposed(by: owner.disposeBag)
                     
                 case let .exclude(media):
                     break

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -42,14 +42,21 @@ extension RecordViewModel {
     
     struct Input {
         let viewDidLoad: Signal<Void>
+        
         let selectButtonTapped: Signal<Void>
         let selectCancelButtonTapped: Signal<Void>
+        
         let recentIndexPath: BehaviorRelay<IndexPath>
+        
         let recordCellSelected: Signal<IndexPath>
         let recordCellDeselected: Signal<IndexPath>
+        
+        let contextMenuPresented: Signal<IndexPath>
+        
         let favoriteToolbarButtonTapped: Signal<Void>
         let excludeToolbarButtonTapped: Signal<Void>
         let removeToolbarButtonTapped: Signal<Void>
+        
         let finishButtonTapped: Signal<Void>
     }
     
@@ -64,8 +71,11 @@ extension RecordViewModel {
         let shoudBeFavorite = BehaviorRelay<Bool>(value: true)
         
         let viewDidRefresh = PublishRelay<Void>()
+        
         let setupSeeMoreMenu = BehaviorRelay<[MenuModel]>(value: [])
         let setupSeeMoreToolbarMenu = BehaviorRelay<[MenuModel]>(value: [])
+        let selectedContextMenu = BehaviorRelay<[MenuModel]>(value: [])
+        
         let switchSelectMode = PublishRelay<Bool>()
         let alertPresented = PublishRelay<AlertModel>()
         let actionSheetPresented = PublishRelay<ActionSheetModel>()
@@ -236,6 +246,12 @@ extension RecordViewModel {
                 currentCells.removeAll(where: { $0 == indexPath })
                 owner.output.selectedRecordCells.accept(currentCells)
                 owner.output.shoudBeFavorite.accept(owner.shouldBeFavorite())
+            }
+            .disposed(by: disposeBag)
+        
+        input.contextMenuPresented
+            .emit(with: self) { owner, indexPath in
+                owner.output.selectedContextMenu.accept([])
             }
             .disposed(by: disposeBag)
         

--- a/poporazzi/Feature/3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/3.Record/RecordViewModel.swift
@@ -101,16 +101,16 @@ extension RecordViewModel {
         case finishWithoutRecord
     }
     
-    enum ActionSheetAction {
-        case exclude([Media])
-        case remove([Media])
-    }
-    
     enum MenuAction {
         case editAlbum
         case excludeRecord
         case noSave
         case share
+    }
+    
+    enum ActionSheetAction {
+        case exclude([Media])
+        case remove([Media])
     }
     
     enum ContextMenuAction {
@@ -334,6 +334,7 @@ extension RecordViewModel {
                 case let .remove(mediaList):
                     owner.output.toggleLoading.accept(true)
                     owner.photoKitService.deletePhotos(from: mediaList.map(\.id))
+                        .observe(on: MainScheduler.asyncInstance)
                         .bind { isSuccess in
                             if isSuccess {
                                 owner.cancelSelectMode()

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewModel.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewModel.swift
@@ -22,6 +22,7 @@ final class ExcludeRecordViewModel: ViewModel {
     let delegate = PublishRelay<Delegate>()
     let actionSheetAction = PublishRelay<ActionSheetAction>()
     let menuAction = PublishRelay<MenuAction>()
+    let contextMenuAction = PublishRelay<ContextMenuAction>()
     
     init(output: Output) {
         self.output = output
@@ -39,10 +40,15 @@ extension ExcludeRecordViewModel {
     struct Input {
         let viewDidLoad: Signal<Void>
         let backButtonTapped: Signal<Void>
+        
         let selectButtonTapped: Signal<Void>
         let selectCancelButtonTapped: Signal<Void>
+        
         let recordCellSelected: Signal<IndexPath>
         let recordCellDeselected: Signal<IndexPath>
+        
+        let contextMenuPresented: Signal<IndexPath>
+        
         let favoriteToolbarButtonTapped: Signal<Void>
         let recoverButtonTapped: Signal<Void>
         let removeButtonTapped: Signal<Void>
@@ -59,7 +65,10 @@ extension ExcludeRecordViewModel {
         let viewDidRefresh = PublishRelay<Void>()
         let alertPresented = PublishRelay<AlertModel>()
         let actionSheetPresented = PublishRelay<ActionSheetModel>()
+        
         let setupSeeMoreToolbarMenu = BehaviorRelay<[MenuModel]>(value: [])
+        let selectedContextMenu = BehaviorRelay<[MenuModel]>(value: [])
+        
         let toggleLoading = PublishRelay<Bool>()
     }
     
@@ -73,13 +82,20 @@ extension ExcludeRecordViewModel {
         case completeSharing
     }
     
-    enum ActionSheetAction {
-        case recover
-        case remove
-    }
-    
     enum MenuAction {
         case share
+    }
+    
+    enum ActionSheetAction {
+        case recover([Media])
+        case remove([Media])
+    }
+    
+    enum ContextMenuAction {
+        case toggleFavorite(Media)
+        case share(Media)
+        case recover(Media)
+        case remove(Media)
     }
 }
 
@@ -113,7 +129,7 @@ extension ExcludeRecordViewModel {
         input.selectButtonTapped
             .emit(with: self) { owner, _ in
                 owner.output.switchSelectMode.accept(true)
-                owner.output.shoudBeFavorite.accept(owner.shouldBeFavorite())
+                owner.output.shoudBeFavorite.accept(owner.shouldBeFavorite(from: owner.selectedMediaList()))
                 HapticManager.impact(style: .light)
             }
             .disposed(by: disposeBag)
@@ -129,7 +145,7 @@ extension ExcludeRecordViewModel {
                 var currentCells = owner.output.selectedRecordCells.value
                 currentCells.append(indexPath)
                 owner.output.selectedRecordCells.accept(currentCells)
-                owner.output.shoudBeFavorite.accept(owner.shouldBeFavorite())
+                owner.output.shoudBeFavorite.accept(owner.shouldBeFavorite(from: owner.selectedMediaList()))
             }
             .disposed(by: disposeBag)
         
@@ -138,7 +154,15 @@ extension ExcludeRecordViewModel {
                 var currentCells = owner.output.selectedRecordCells.value
                 currentCells.removeAll(where: { $0 == indexPath })
                 owner.output.selectedRecordCells.accept(currentCells)
-                owner.output.shoudBeFavorite.accept(owner.shouldBeFavorite())
+                owner.output.shoudBeFavorite.accept(owner.shouldBeFavorite(from: owner.selectedMediaList()))
+            }
+            .disposed(by: disposeBag)
+        
+        input.contextMenuPresented
+            .emit(with: self) { owner, indexPath in
+                let selectedMedia = owner.output.mediaList.value[indexPath.row]
+                let contextMenu = owner.contextMenu(from: selectedMedia)
+                owner.output.selectedContextMenu.accept(contextMenu)
             }
             .disposed(by: disposeBag)
         
@@ -146,7 +170,7 @@ extension ExcludeRecordViewModel {
             .emit(with: self) { owner, _ in
                 owner.photoKitService.toggleFavorite(
                     from: owner.selectedAssetIdentifiers(),
-                    isFavorite: owner.shouldBeFavorite()
+                    isFavorite: owner.shouldBeFavorite(from: owner.selectedMediaList())
                 )
                 owner.cancelSelectMode()
             }
@@ -154,24 +178,22 @@ extension ExcludeRecordViewModel {
         
         input.recoverButtonTapped
             .emit(with: self) { owner, _ in
-                owner.output.actionSheetPresented.accept(owner.recoverActionSheet)
+                owner.output.actionSheetPresented.accept(owner.recoverActionSheet(from: owner.selectedMediaList()))
             }
             .disposed(by: disposeBag)
         
         input.removeButtonTapped
             .emit(with: self) { owner, _ in
-                owner.output.actionSheetPresented.accept(owner.removeActionSheet)
+                owner.output.actionSheetPresented.accept(owner.removeActionSheet(from: owner.selectedMediaList()))
             }
             .disposed(by: disposeBag)
         
         actionSheetAction
             .bind(with: self) { owner, action in
                 switch action {
-                case .recover:
-                    let assetIdentifiers = owner.selectedAssetIdentifiers()
-                    
+                case let .recover(mediaList):
                     var album = owner.output.album.value
-                    album.excludeMediaList.subtract(assetIdentifiers)
+                    album.excludeMediaList.subtract(mediaList.map(\.id))
                     owner.output.album.accept(album)
                     
                     owner.output.viewDidRefresh.accept(())
@@ -180,14 +202,15 @@ extension ExcludeRecordViewModel {
                     owner.navigation.accept(.updateRecord(owner.output.album.value))
                     owner.persistenceService.updateAlbumExcludeMediaList(to: album)
                     
-                case .remove:
+                case let .remove(mediaList):
                     owner.output.toggleLoading.accept(true)
-                    let assetIdentifiers = owner.selectedAssetIdentifiers()
-                    owner.photoKitService.deletePhotos(from: assetIdentifiers)
+                    let identifiers = mediaList.map(\.id)
+                    owner.photoKitService.deletePhotos(from: identifiers)
+                        .observe(on: MainScheduler.asyncInstance)
                         .bind { isSuccess in
                             if isSuccess {
                                 var album = owner.output.album.value
-                                album.excludeMediaList.subtract(assetIdentifiers)
+                                album.excludeMediaList.subtract(identifiers)
                                 owner.output.album.accept(album)
                                 
                                 owner.cancelSelectMode()
@@ -211,6 +234,33 @@ extension ExcludeRecordViewModel {
                             owner.navigation.accept(.presentMediaShareSheet(shareItemList))
                         }
                         .disposed(by: owner.disposeBag)
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        contextMenuAction
+            .bind(with: self) { owner, action in
+                switch action {
+                case let .toggleFavorite(media):
+                    owner.photoKitService.toggleFavorite(
+                        from: [media.id],
+                        isFavorite: owner.shouldBeFavorite(from: [media])
+                    )
+                    
+                case let .share(media):
+                    owner.photoKitService.fetchShareItemList(from: [media.id])
+                        .bind { shareItemList in
+                            owner.navigation.accept(.presentMediaShareSheet(shareItemList))
+                        }
+                        .disposed(by: owner.disposeBag)
+                    
+                case let .recover(media):
+                    owner.output.actionSheetPresented.accept(owner.recoverActionSheet(from: [media]))
+                    HapticManager.notification(type: .warning)
+                    
+                case let .remove(media):
+                    owner.output.actionSheetPresented.accept(owner.removeActionSheet(from: [media]))
+                    HapticManager.notification(type: .warning)
                 }
             }
             .disposed(by: disposeBag)
@@ -245,9 +295,8 @@ extension ExcludeRecordViewModel {
     }
     
     /// 선택한 Media의 다음 즐겨찾기 값을 계산합니다.
-    private func shouldBeFavorite() -> Bool {
-        let selectedMediaList = selectedMediaList()
-        let isFavoriteSet = Set(selectedMediaList.map(\.isFavorite))
+    private func shouldBeFavorite(from mediaList: [Media]) -> Bool {
+        let isFavoriteSet = Set(mediaList.map(\.isFavorite))
         
         if isFavoriteSet.count > 1 {
             return isFavoriteSet.contains(true)
@@ -293,12 +342,11 @@ extension ExcludeRecordViewModel {
 extension ExcludeRecordViewModel {
     
     /// 앨범으로 복구 Action Sheet
-    private var recoverActionSheet: ActionSheetModel {
-        let selectedCount = output.selectedRecordCells.value.count
-        return ActionSheetModel(
+    private func recoverActionSheet(from mediaList: [Media]) -> ActionSheetModel {
+        ActionSheetModel(
             buttons: [
-                .init(title: "\(selectedCount)장의 기록 앨범으로 복구", style: .default) { [weak self] in
-                    self?.actionSheetAction.accept(.recover)
+                .init(title: "\(mediaList.count)장의 기록 앨범으로 복구", style: .default) { [weak self] in
+                    self?.actionSheetAction.accept(.recover(mediaList))
                 },
                 .init(title: "취소", style: .cancel)
             ]
@@ -306,13 +354,12 @@ extension ExcludeRecordViewModel {
     }
     
     /// 기록 삭제 Action Sheet
-    private var removeActionSheet: ActionSheetModel {
-        let selectedCount = output.selectedRecordCells.value.count
+    private func removeActionSheet(from mediaList: [Media]) -> ActionSheetModel {
         return ActionSheetModel(
             message: "선택한 기록이 ‘사진’ 앱에서 삭제돼요. 삭제한 항목은 사진 앱의 ‘최근 삭제된 항목’에 30일간 보관돼요.",
             buttons: [
-                .init(title: "\(selectedCount)장의 기록 삭제", style: .destructive) { [weak self] in
-                    self?.actionSheetAction.accept(.remove)
+                .init(title: "\(mediaList.count)장의 기록 삭제", style: .destructive) { [weak self] in
+                    self?.actionSheetAction.accept(.remove(mediaList))
                 },
                 .init(title: "취소", style: .cancel)
             ]
@@ -330,5 +377,25 @@ extension ExcludeRecordViewModel {
             self?.menuAction.accept(.share)
         }
         return [share]
+    }
+    
+    /// Context Menu
+    private func contextMenu(from media: Media) -> [MenuModel] {
+        let favorite = MenuModel(
+            symbol: media.isFavorite ? .favoriteRemoveLine : .favoriteActiveLine,
+            title: media.isFavorite ? "즐겨찾기 해제" : "즐겨찾기"
+        ) { [weak self] in
+            self?.contextMenuAction.accept(.toggleFavorite(media))
+        }
+        let share = MenuModel(symbol: .share, title: "공유하기") { [weak self] in
+            self?.contextMenuAction.accept(.share(media))
+        }
+        let recover = MenuModel(symbol: .exclude, title: "앨범으로 복구하기") { [weak self] in
+            self?.contextMenuAction.accept(.recover(media))
+        }
+        let remove = MenuModel(symbol: .removeLine, title: "삭제하기", attributes: .destructive) { [weak self] in
+            self?.contextMenuAction.accept(.remove(media))
+        }
+        return [favorite, share, recover, remove]
     }
 }

--- a/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewModel.swift
+++ b/poporazzi/Feature/6.ExcludeRecord/ExcludeRecordViewModel.swift
@@ -64,7 +64,8 @@ extension ExcludeRecordViewModel {
     }
     
     enum Navigation {
-        case pop(Album)
+        case pop
+        case updateRecord(Album)
         case presentMediaShareSheet([Any])
     }
     
@@ -105,7 +106,7 @@ extension ExcludeRecordViewModel {
         
         input.backButtonTapped
             .emit(with: self) { owner, _ in
-                owner.navigation.accept(.pop(owner.output.album.value))
+                owner.navigation.accept(.pop)
             }
             .disposed(by: disposeBag)
         
@@ -176,6 +177,7 @@ extension ExcludeRecordViewModel {
                     owner.output.viewDidRefresh.accept(())
                     owner.cancelSelectMode()
                     
+                    owner.navigation.accept(.updateRecord(owner.output.album.value))
                     owner.persistenceService.updateAlbumExcludeMediaList(to: album)
                     
                 case .remove:

--- a/poporazzi/Utility/SFSymbol+.swift
+++ b/poporazzi/Utility/SFSymbol+.swift
@@ -21,9 +21,15 @@ enum SFSymbol: String {
     case check = "checkmark"
     case checkBox = "checkmark.square.fill"
     case noSave = "xmark.bin"
-    case favoriteRemove = "heart.slash.fill"
+    
     case favoriteActive = "heart.fill"
+    case favoriteRemove = "heart.slash.fill"
+    case favoriteActiveLine = "heart"
+    case favoriteRemoveLine = "heart.slash"
+    
     case remove = "trash.fill"
+    case removeLine = "trash"
+    
     case share = "square.and.arrow.up"
 }
 


### PR DESCRIPTION
close #114

## *⛳️ Work Description*
- Record, ExcludeRecord 각 CollectionView Context Menu 기능 구현(즐겨찾기, 공유하기, 제외 및 복구, 삭제하기)

## *🧐 트러블슈팅*
UICollectionViewDelegate 채택 후 `collectionView(_:contextMenuConfigurationForItemAt:point:)` Delegate 메서드를 이용해 쉽게 Context Menu 구현이 가능합니다.

~~~swift
// MARK: - UICollectionViewDelegate

extension RecordViewController: UICollectionViewDelegate {
    
    /// 선택된 IndexPath의 Context Menu를 설정합니다.
    func collectionView(
        _ collectionView: UICollectionView,
        contextMenuConfigurationForItemAt indexPath: IndexPath,
        point: CGPoint
    ) -> UIContextMenuConfiguration? {
        contextMenuPresented.accept(indexPath) // ⭐️ ViewModel로 IndexPath 전달
        return UIContextMenuConfiguration(
            identifier: nil,
            previewProvider: nil,
            actionProvider: { [weak self] _ in
                self?.selectedContextMenu.value.toUIMenu // ⭐️ UIMenu 받아와서 표시
            }
        )
    }
}
~~~

## *📸 Screenshot*
|기능|스크린샷|
|:--:|:--:|
|Context Menu|<img width="300" alt="" src="https://github.com/user-attachments/assets/2494352b-29ad-4426-a156-fc5d0d944454">|