### PR TITLE
Live Activity 종료되지 않는 현상 해결

### DIFF
--- a/poporazzi/Data/Service/LiveActivityService.swift
+++ b/poporazzi/Data/Service/LiveActivityService.swift
@@ -11,6 +11,10 @@ import ActivityKit
 final class LiveActivityService: LiveActivityInterface {
     
     private var activity: Activity<PoporazziWidgetAttributes>?
+    
+    init() {
+        self.activity = Activity<PoporazziWidgetAttributes>.activities.first
+    }
 }
 
 // MARK: - Use Case


### PR DESCRIPTION
close #116

## *⛳️ Work Description*
- Live Activity 종료되지 않는 현상 해결

## *🧐 트러블슈팅*
### 1. 왜 Live Activity는 종료되지 않았을까?
Live Activity를 관리하는 객체의 코드를 살펴보면, `Activity<PoporazziWidgetAttributes>` 타입을 전역 변수로 두고 이를 제어하고 있습니다.
~~~swift
final class LiveActivityService: LiveActivityInterface {
    
    private var activity: Activity<PoporazziWidgetAttributes>?
}

// MARK: - Use Case

extension LiveActivityService {
    
    /// Live Activity를 시작합니다.
    func start(to album: Album) {
        guard activity == nil else { return }
        let attributes = PoporazziWidgetAttributes()
        let contentState = PoporazziWidgetAttributes.ContentState(
            albumTitle: album.title,
            startDate: album.startDate,
            totalCount: 0
        )
        let content = ActivityContent(state: contentState, staleDate: nil)
        
        do {
            activity = try Activity<PoporazziWidgetAttributes>.request(
                attributes: attributes,
                content: content,
                pushType: nil
            )
        } catch {
            print(error)
        }
    }
    
    /// Live Activity를 업데이트합니다.
    func update(to album: Album, totalCount: Int) {
        guard let activity = activity else { return }
        
        let contentState = PoporazziWidgetAttributes.ContentState(
            albumTitle: album.title,
            startDate: album.startDate,
            totalCount: totalCount
        )
        let content = ActivityContent(state: contentState, staleDate: nil)
        
        Task {
            await activity.update(content)
        }
    }
    
    /// Live Activity를 종료합니다.
    func stop() {
        Task {
            await activity?.end(nil, dismissalPolicy: .immediate)
            self.activity = nil
        }
    }
}
~~~

이는 앱 실행 중 Live Activity를 실행 시켜 전역 변수를 업데이트 했을 때는 문제가 없지만, 앱 종료 후에도 Live Activity가 살아있는 경우, 다시 제어할 수 없는 구조이기 때문에, 종료 시 `activity` 변수는 nil을 반환하게 됩니다.

이를 해결하기 위해 현재 실행 중인 Live Activity의 배열을 받아오는 `activities` 타입 프로퍼티를 이용해 생성 시 재할당 할 수 있게 수정해주었습니다.
~~~swift
final class LiveActivityService: LiveActivityInterface {
    
    private var activity: Activity<PoporazziWidgetAttributes>?
    
    init() {
        self.activity = Activity<PoporazziWidgetAttributes>.activities.first // ⭐️ 생성 시 재할당
    }
}
~~~