### PR TITLE
애니메이션 적용 시 터치 이벤트 먹힘 현상 수정

### DIFF
--- a/poporazzi/UIComponent/FormCheckBox.swift
+++ b/poporazzi/UIComponent/FormCheckBox.swift
@@ -69,7 +69,7 @@ extension FormCheckBox {
     func action(_ action: Action) {
         switch action {
         case let .updateVariation(variation):
-            UIView.animate(withDuration: 0.2) { [weak self] in
+            UIView.animate(withDuration: 0.2, delay: 0, options: .allowUserInteraction) { [weak self] in
                 self?.checkBoxIcon.tintColor = variation.backgroundColor
             }
         }

--- a/poporazzi/UIComponent/FormChoiceChip.swift
+++ b/poporazzi/UIComponent/FormChoiceChip.swift
@@ -70,7 +70,7 @@ extension FormChoiceChip {
     func action(_ action: Action) {
         switch action {
         case let .updateVariation(variation):
-            UIView.animate(withDuration: 0.2) { [weak self] in
+            UIView.animate(withDuration: 0.2, delay: 0, options: .allowUserInteraction) { [weak self] in
                 self?.button.backgroundColor = variation.backgroundColor
                 self?.button.setTitleColor(variation.textColor, for: .normal)
             }

--- a/poporazzi/UIComponent/TabBar.swift
+++ b/poporazzi/UIComponent/TabBar.swift
@@ -66,9 +66,9 @@ extension TabBar {
     func action(_ action: Action) {
         switch action {
         case let .updateTab(tab):
-            UIView.animate(withDuration: 0.2) { [weak self] in
+            selectedTab = tab
+            UIView.animate(withDuration: 0.2, delay: 0, options: .allowUserInteraction) { [weak self] in
                 guard let self else { return }
-                selectedTab = tab
                 switch tab {
                 case .albumList:
                     albumListButton.alpha = 1


### PR DESCRIPTION
close #112

## *⛳️ Work Description*
- 애니메이션 버그 수정

## *🧐 트러블슈팅*
### 1. 왜 애니메이션 후 이벤트가 작동하지 않았을까?
기존 모든 애니메이션은 `UIView.animate`를 사용해 구현되었습니다. 이는 0.2초의 시간 동안 점진적으로 View를 업데이트 시키는 방법으로, 처음에는 문제 상황을 인지하지 못했습니다.
~~~swift
UIView.animate(withDuration: 0.2) { [weak self] in
    // ...
}
~~~

하지만 이는 0.2초 간의 애니메이션이 변화되는 시점에 터치 이벤트가 재발생했을 때 정상적으로 동작하지 않는 것을 확인했습니다. 이를 해결하기 위해 검색 후 아래와 같이 option 값을 설정함으로써 해결할 수 있었습니다. (`allowUserInteraction` 옵션은 사용자가 애니메이션ㅇ르 하는 동안 View와 상호작용하는 것을 가능하게 만들어줍니다.)
~~~swift
UIView.animate(withDuration: 0.2, delay: 0, options: .allowUserInteraction) { [weak self] in
    // ...
}
~~~