### PR TITLE
앨범 기록 예약 Notification 취소 로직 구현

### DIFF
--- a/poporazzi/Data/Service/UserNotificationService.swift
+++ b/poporazzi/Data/Service/UserNotificationService.swift
@@ -60,4 +60,9 @@ struct UserNotificationService: UserNotificationInterface {
         
         UNUserNotificationCenter.current().add(request) { _ in }
     }
+    
+    /// 등록된 전체 Notification을 취소합니다.
+    func cancelAllNotification() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
 }

--- a/poporazzi/Domain/Interface/UserNotificationInterface.swift
+++ b/poporazzi/Domain/Interface/UserNotificationInterface.swift
@@ -18,4 +18,7 @@ protocol UserNotificationInterface {
     
     /// Notification을 등록합니다.
     func registerNotification(title: String, body: String, triggerDate: Date)
+    
+    /// 등록된 전체 Notification을 취소합니다.
+    func cancelAllNotification()
 }

--- a/poporazzi/Feature/2.Record/2-3.Record/RecordViewModel.swift
+++ b/poporazzi/Feature/2.Record/2-3.Record/RecordViewModel.swift
@@ -14,6 +14,7 @@ final class RecordViewModel: ViewModel {
     @Dependency(\.persistenceService) private var persistenceService
     @Dependency(\.liveActivityService) private var liveActivityService
     @Dependency(\.photoKitService) private var photoKitService
+    @Dependency(\.userNotificationService) private var userNotificationService
     
     private let paginationManager = PaginationManager(pageSize: 100, threshold: 10)
     
@@ -337,6 +338,7 @@ extension RecordViewModel {
                 case .finishWithoutRecord:
                     owner.navigation.accept(.stopRecord)
                     owner.liveActivityService.stop()
+                    owner.userNotificationService.cancelAllNotification()
                     UserDefaultsService.trackingAlbumId = ""
                 }
             }

--- a/poporazzi/Feature/2.Record/2-6.FinishConfirmModal/FinishConfirmModalViewModel.swift
+++ b/poporazzi/Feature/2.Record/2-6.FinishConfirmModal/FinishConfirmModalViewModel.swift
@@ -13,6 +13,7 @@ final class FinishConfirmModalViewModel: ViewModel {
     
     @Dependency(\.liveActivityService) private var liveActivityService
     @Dependency(\.photoKitService) private var photoKitService
+    @Dependency(\.userNotificationService) private var userNotificationService
     
     private let disposeBag = DisposeBag()
     private let output: Output
@@ -115,8 +116,9 @@ extension FinishConfirmModalViewModel {
     
     /// 기록을 종료합니다.
     private func finishRecord() {
-        liveActivityService.stop()
         navigation.accept(.finishRecord)
+        liveActivityService.stop()
+        userNotificationService.cancelAllNotification()
         HapticManager.notification(type: .success)
         UserDefaultsService.trackingAlbumId = ""
     }


### PR DESCRIPTION
close #150

## *⛳️ Work Description*
- UserNotification 취소 로직 구현

## *🧐 트러블슈팅*
~~~swift
/// 등록된 전체 Notification을 취소합니다.
func cancelAllNotification() {
    UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
}
~~~