### PR TITLE
온보딩 화면 계속 나타나는 문제 해결

### DIFF
--- a/poporazzi.xcodeproj/project.pbxproj
+++ b/poporazzi.xcodeproj/project.pbxproj
@@ -473,7 +473,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.3;
+				MARKETING_VERSION = 1.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.thinkyside.poporazzi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -511,7 +511,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.3;
+				MARKETING_VERSION = 1.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.thinkyside.poporazzi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/poporazzi/App/Coordinator.swift
+++ b/poporazzi/App/Coordinator.swift
@@ -12,6 +12,7 @@ import RxCocoa
 final class Coordinator: NSObject {
     
     @Dependency(\.persistenceService) var persistenceService
+    @Dependency(\.photoKitService) var photoKitService
     
     private var window: UIWindow?
     
@@ -153,7 +154,8 @@ final class Coordinator: NSObject {
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
         
-        if UserDefaultsService.isFirstLaunch {
+        let status = photoKitService.checkPermission()
+        if status != .authorized {
             let onboardingVM = OnboardingViewModel(output: .init(isOnboarding: .init(value: true)))
             let onboardingVC = OnboardingViewController(viewModel: onboardingVM)
             onboardingVC.modalPresentationStyle = .overFullScreen

--- a/poporazzi/Data/Service/UserDefaultsService.swift
+++ b/poporazzi/Data/Service/UserDefaultsService.swift
@@ -13,9 +13,6 @@ struct UserDefaultsService {
     
     @UserDefault(key: "trackingAlbumId", defaultValue: "")
     static var trackingAlbumId: String
-    
-    @UserDefault(key: "isFirstLaunch", defaultValue: true)
-    static var isFirstLaunch: Bool
 }
 
 // MARK: - propertyWrapper

--- a/poporazzi/Feature/6.Onboarding/5-2.PermissionRequestModal/PermissionRequestModalViewModel.swift
+++ b/poporazzi/Feature/6.Onboarding/5-2.PermissionRequestModal/PermissionRequestModalViewModel.swift
@@ -73,7 +73,6 @@ extension PermissionRequestModalViewModel {
                                 
                             case .authorized:
                                 owner.navigation.accept(.dismiss)
-                                UserDefaultsService.isFirstLaunch = false
                                 
                             @unknown default:
                                 break


### PR DESCRIPTION
close #152

## *⛳️ Work Description*
- 특정 조건에서 온보딩 화면이 계속 나타나는 문제를 해결합니다.

## *🧐 트러블슈팅*
### 1. 온보딩 로직 업데이트
기존 온보딩 로직은 UserDefaults 값을 이용해 `isFirstLaunch` 값을 검사 후 분기하는 로직이었습니다. 이는 해당 값이 명확하게 업데이트 되지 않을 시 혹은 설정 앱에서 사진 접근 권한을 허용하지 않았을 때는 업데이트할 수 없어 분기에 오류를 만들고 있었습니다.

이를 해결하기 위해 직접적으로 UserDefaults 값을 확인하는 로직에서, PhotoLibrary의 권한을 이용한 로직으로 업데이트했습니다.

~~~swift
let status = photoKitService.checkPermission()
        if status != .authorized {
            // 온보딩 화면 출력 ...
        }
~~~